### PR TITLE
Dev/ledger model round trip (#72)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,47 @@
 This document follows the guidelines of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.28.0] - 2025-09-24
+
+### Added
+
+- **FinancialMovementModel – Tests:** casos para normalización de montos, *round-trip* JSON y
+  diferencias por `mathPrecision`.
+- **Utils.listFromDynamic – Tests:** validación con entradas mixtas (ruido, llaves extra, `null`) y
+  verificación de compatibilidad con `LedgerModel.fromJson`.
+- **LedgerModel – Tests:** cobertura para JSON en formas válidas variadas, inmutabilidad, balance
+  entero/decimal, igualdad/hash y sensibilidad al orden.
+
+### Changed
+
+- **FinancialMovementModel:**
+  - **Política de no-negativos:** `fromDecimal`, `fromJson` y `copyWith` normalizan montos con
+    `abs()`. El signo **no** codifica ingreso/egreso (lo define `category`).
+  - **`mathPrecision`:** ahora se **lee/escribe** en JSON y forma parte de `==`/`hashCode`.
+  - **`fromJson`:** usa `containsKey` para distinguir entre valor provisto y `defaultMathPrecision`.
+- **LedgerModel (inmutabilidad):**
+  - `fromJson` y `copyWith` envuelven listas con `List.unmodifiable`.
+  - Se documenta que el **ctor principal** espera listas ya inmutables.
+- **Igualdad/orden (`LedgerModel`):** se mantiene igualdad profunda **sensible al orden** y
+  `hashCode` consistente con ese contrato.
+
+### Fixed
+
+- **LedgerModel:** corrección crítica en `_listHash` para usar `e.hashCode` (eliminado
+  `e?.hashCode`) evitando discrepancias de hash.
+
+### Docs
+
+- **FinancialMovementModel:** contrato aclarado (entero escalado, uso recomendado de `fromDecimal`,
+  límites de precisión) y ejemplo mínimo.
+- **LedgerModel:** contrato de inmutabilidad, ejemplo mínimo y nota sobre costo de `toString()`.
+
+> **Notas:**
+> - El modelo financiero ahora **siempre** almacena montos no negativos; si tu lógica dependía del
+    signo para distinguir ingreso/egreso, usa el campo `category`.
+> - Al incorporarse `mathPrecision` a `==`/`hashCode`, comparaciones y *sets/maps* podrían cambiar
+    si mezclas precisiones distintas para el mismo valor numérico.
+
 ## [1.27.0] - 2025-09-13
 
 ### Added

--- a/lib/domain/financial/ledger_model.dart
+++ b/lib/domain/financial/ledger_model.dart
@@ -1,72 +1,90 @@
 part of '../../jocaagura_domain.dart';
 
-/// Enum que representa los campos de un libro contable.
-enum LedgerEnum {
-  /// Nombre del libro contable.
-  nameOfLedger,
+enum LedgerEnum { nameOfLedger, incomeLedger, expenseLedger }
 
-  /// Lista de ingresos.
-  incomeLedger,
-
-  /// Lista de egresos.
-  expenseLedger,
-}
-
-/// Representa un libro contable que agrupa los movimientos financieros de un usuario.
+/// Represents a financial ledger composed of incomes and expenses.
 ///
-/// Cada libro contiene una lista de ingresos y egresos, calculando totales y permitiendo
-/// operaciones básicas de análisis financiero.
+/// This model aggregates two collections of [FinancialMovementModel] and
+/// exposes derived balances in both scaled integer (`balance`) and decimal
+/// form (`decimalBalance`). It is intended to be *logically immutable*:
+/// factories and `copyWith` wrap collections using `List.unmodifiable`.
+///
+/// **Immutability contract**
+/// - The default constructor expects **already unmodifiable** lists; it does
+///   not wrap them to preserve `const` usage and API compatibility.
+/// - Prefer building instances via `fromJson` or `copyWith`, which enforce
+///   unmodifiable collections internally.
+/// - Mutating the provided lists *after* passing them to the constructor
+///   breaks the immutability assumptions and may invalidate `==`/`hashCode`.
+///
+/// **Equality and hashing**
+/// - Deep equality is performed in order (index-by-index).
+/// - `hashCode` is derived from list contents to remain consistent with `==`.
+///
+/// Minimal example:
+/// ```dart
+/// void main() {
+///   final LedgerModel ledger = LedgerModel.fromJson(<String, dynamic>{
+///     'nameOfLedger': 'My Ledger',
+///     'incomeLedger': <Map<String, dynamic>>[defaultMovement.toJson()],
+///     'expenseLedger': <Map<String, dynamic>>[],
+///   });
+///   print(ledger.balance);        // total incomes - total expenses (scaled int)
+///   print(ledger.decimalBalance); // decimal difference
+/// }
+/// ```
 class LedgerModel extends Model {
-  /// Crea una instancia de [LedgerModel].
   const LedgerModel({
     required this.nameOfLedger,
     required this.incomeLedger,
     required this.expenseLedger,
   });
 
-  /// Crea una instancia de [LedgerModel] a partir de un JSON.
   factory LedgerModel.fromJson(Map<String, dynamic> json) {
+    final String name =
+        Utils.getStringFromDynamic(json[LedgerEnum.nameOfLedger.name]);
+
+    final List<Map<String, dynamic>> incomeRaw =
+        Utils.listFromDynamic(json[LedgerEnum.incomeLedger.name]);
+    final List<Map<String, dynamic>> expenseRaw =
+        Utils.listFromDynamic(json[LedgerEnum.expenseLedger.name]);
+
+    final List<FinancialMovementModel> incomes =
+        incomeRaw.map(FinancialMovementModel.fromJson).toList(growable: false);
+    final List<FinancialMovementModel> expenses =
+        expenseRaw.map(FinancialMovementModel.fromJson).toList(growable: false);
+
     return LedgerModel(
-      nameOfLedger:
-          Utils.getStringFromDynamic(json[LedgerEnum.nameOfLedger.name]),
-      incomeLedger: Utils.listFromDynamic(json[LedgerEnum.incomeLedger.name])
-          .map(FinancialMovementModel.fromJson)
-          .toList(),
-      expenseLedger: Utils.listFromDynamic(json[LedgerEnum.expenseLedger.name])
-          .map(FinancialMovementModel.fromJson)
-          .toList(),
+      nameOfLedger: name,
+      incomeLedger: List<FinancialMovementModel>.unmodifiable(incomes),
+      expenseLedger: List<FinancialMovementModel>.unmodifiable(expenses),
     );
   }
 
-  /// Nombre del libro contable.
   final String nameOfLedger;
 
-  /// Lista de ingresos.
+  // Nota: siguen expuestos como List<...> para no romper API ni const-ctor.
   final List<FinancialMovementModel> incomeLedger;
-
-  /// Lista de egresos.
   final List<FinancialMovementModel> expenseLedger;
 
-  /// Retorna el saldo total del libro (ingresos - egresos).
   int get balance =>
       MoneyUtils.totalAmount(incomeLedger) -
       MoneyUtils.totalAmount(expenseLedger);
 
-  /// Retorna el saldo total del libro en formato decimal.
   double get decimalBalance =>
       MoneyUtils.totalDecimalAmount(incomeLedger) -
       MoneyUtils.totalDecimalAmount(expenseLedger);
 
   @override
-  Map<String, dynamic> toJson() {
-    return <String, dynamic>{
-      LedgerEnum.nameOfLedger.name: nameOfLedger,
-      LedgerEnum.incomeLedger.name:
-          incomeLedger.map((FinancialMovementModel e) => e.toJson()).toList(),
-      LedgerEnum.expenseLedger.name:
-          expenseLedger.map((FinancialMovementModel e) => e.toJson()).toList(),
-    };
-  }
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        LedgerEnum.nameOfLedger.name: nameOfLedger,
+        LedgerEnum.incomeLedger.name: incomeLedger
+            .map((FinancialMovementModel e) => e.toJson())
+            .toList(growable: false),
+        LedgerEnum.expenseLedger.name: expenseLedger
+            .map((FinancialMovementModel e) => e.toJson())
+            .toList(growable: false),
+      };
 
   @override
   LedgerModel copyWith({
@@ -76,25 +94,55 @@ class LedgerModel extends Model {
   }) {
     return LedgerModel(
       nameOfLedger: nameOfLedger ?? this.nameOfLedger,
-      incomeLedger: incomeLedger ?? this.incomeLedger,
-      expenseLedger: expenseLedger ?? this.expenseLedger,
+      // copy defensiva e inmutable si vienen nuevas listas
+      incomeLedger: incomeLedger == null
+          ? this.incomeLedger
+          : List<FinancialMovementModel>.unmodifiable(incomeLedger),
+      expenseLedger: expenseLedger == null
+          ? this.expenseLedger
+          : List<FinancialMovementModel>.unmodifiable(expenseLedger),
     );
   }
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        other is LedgerModel &&
-            nameOfLedger == other.nameOfLedger &&
-            incomeLedger == other.incomeLedger &&
-            expenseLedger == other.expenseLedger;
+  static bool _listEquals<T>(List<T> a, List<T> b) {
+    if (identical(a, b)) {
+      return true;
+    }
+    if (a.length != b.length) {
+      return false;
+    }
+    for (int i = 0; i < a.length; i += 1) {
+      if (a[i] != b[i]) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  static int _listHash<T>(List<T> list) {
+    int hash = 17;
+    for (final T e in list) {
+      hash = 37 * hash + e.hashCode;
+    }
+    return hash;
   }
 
   @override
-  int get hashCode => Object.hash(nameOfLedger, incomeLedger, expenseLedger);
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is LedgerModel &&
+          nameOfLedger == other.nameOfLedger &&
+          _listEquals(incomeLedger, other.incomeLedger) &&
+          _listEquals(expenseLedger, other.expenseLedger);
 
   @override
-  String toString() {
-    return 'LedgerModel(name: $nameOfLedger, balance: $decimalBalance)';
-  }
+  int get hashCode => Object.hash(
+        nameOfLedger,
+        _listHash(incomeLedger),
+        _listHash(expenseLedger),
+      );
+
+  @override
+  String toString() =>
+      'LedgerModel(name: $nameOfLedger, balance: $decimalBalance)';
 }

--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -6,6 +6,55 @@ part of 'jocaagura_domain.dart';
 /// such as emails, URLs, phone numbers, JSON, and dynamic types. It also includes
 /// formatters and validators to ensure proper data handling.
 class Utils extends EntityUtil {
+  /// Formats a 10-digit phone number as `(XX) X XXX XXXX`.
+  ///
+  /// This is an alias that keeps the original behavior while fixing the method
+  /// name spelling and parameter naming. It delegates to
+  /// [getFormatedPhoneNumber] without altering logic.
+  ///
+  /// **Contract**
+  /// - Pads the number to 10 digits on the left with `0` when needed.
+  /// - Does not validate country codes or international formats.
+  /// - Negative numbers will keep their minus sign in the input string before
+  ///   padding, which may lead to unexpected results. Prefer passing non-negative
+  ///   integers only.
+  ///
+  /// Example:
+  /// ```dart
+  /// void main() {
+  ///   final String s = Utils.getFormattedPhoneNumber(3001234567);
+  ///   // "(30) 0 123 4567"
+  ///   print(s);
+  /// }
+  /// ```
+  static String getFormattedPhoneNumber(int phoneNumber) {
+    return getFormatedPhoneNumber(phoneNumber);
+  }
+
+  /// Formats a 10-digit phone number as `XXX XXX XXXX`.
+  ///
+  /// This is an alias that keeps the original behavior while fixing the method
+  /// name spelling and parameter naming. It delegates to
+  /// [getFormatedPhoneNumberAlt] without altering logic.
+  ///
+  /// **Contract**
+  /// - Pads the number to 10 digits on the left with `0` when needed.
+  /// - Not intended for international formats or extensions.
+  /// - Input should be a non-negative integer representing a national 10-digit
+  ///   number; other inputs may yield unexpected formatting.
+  ///
+  /// Example:
+  /// ```dart
+  /// void main() {
+  ///   final String s = Utils.getFormattedPhoneNumberAlt(3001234567);
+  ///   // "300 123 4567"
+  ///   print(s);
+  /// }
+  /// ```
+  static String getFormattedPhoneNumberAlt(int phoneNumber) {
+    return getFormatedPhoneNumberAlt(phoneNumber);
+  }
+
   /// Converts a [Map] into a JSON string.
   ///
   /// - [inputMap]: The map to convert.
@@ -20,28 +69,47 @@ class Utils extends EntityUtil {
     return getJsonEncode(inputMap);
   }
 
-  /// Converts a dynamic value to a [Map].
+  /// Convert a dynamic JSON-like value into a Map<String, dynamic>.
   ///
-  /// - [jsonString]: The dynamic value, either a JSON string or a Map.
-  /// - Returns: A [Map<String, dynamic>], or an empty map if the conversion fails.
+  /// Accepts:
+  /// - A `Map<String, dynamic>` (returned as-is)
+  /// - A raw `Map` with dynamic keys (keys normalized to `String`)
+  /// - A JSON string (decoded to a map)
+  ///
+  /// Returns `{}` when decoding fails (never throws).
   ///
   /// Example:
   /// ```dart
-  /// final Map<String, dynamic> result = Utils.mapFromDynamic('{"key": "value"}');
-  /// print(result); // Output: {key: value}
+  /// void main() {
+  ///   print(Utils.mapFromDynamic('{"a": 1}')); // {a: 1}
+  ///   print(Utils.mapFromDynamic({'x': 2}));   // {x: 2}
+  ///   print(Utils.mapFromDynamic('oops'));     // {}
+  /// }
   /// ```
-  static Map<String, dynamic> mapFromDynamic(dynamic jsonString) {
-    if (jsonString is Map<String, dynamic>) {
-      return jsonString;
+  static Map<String, dynamic> mapFromDynamic(dynamic jsonLike) {
+    if (jsonLike is Map<String, dynamic>) {
+      return jsonLike;
     }
 
-    final dynamic json = jsonDecode(jsonString.toString());
-    if (json is Map) {
-      final Map<String, dynamic> result = <String, dynamic>{};
-      json.forEach((dynamic key, dynamic value) {
-        result['$key'] = value;
+    if (jsonLike is Map) {
+      final Map<String, dynamic> m = <String, dynamic>{};
+      jsonLike.forEach((dynamic k, dynamic v) {
+        m['$k'] = v;
       });
-      return result;
+      return m;
+    }
+
+    try {
+      final dynamic decoded = jsonDecode(jsonLike.toString());
+      if (decoded is Map) {
+        final Map<String, dynamic> result = <String, dynamic>{};
+        decoded.forEach((dynamic k, dynamic v) {
+          result['$k'] = v;
+        });
+        return result;
+      }
+    } catch (_) {
+      return <String, dynamic>{};
     }
 
     return <String, dynamic>{};
@@ -76,21 +144,23 @@ class Utils extends EntityUtil {
   /// - [email]: The string to validate.
   /// - Returns: `true` if the string is a valid email, `false` otherwise.
   static bool isEmail(String email) {
-    final RegExp regex = RegExp(
-      r'^[\w-]+(\.[\w-]+)*@([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,7}$',
-    );
-    return regex.hasMatch(email);
+    final RegExp re =
+        RegExp(r'^[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,24}$');
+    return re.hasMatch(email);
   }
 
   /// Validates if a string is a valid URL format.
   ///
   /// - [url]: The string to validate.
   /// - Returns: `true` if the string is a valid URL, `false` otherwise.
-  static bool isValidUrl(String url) {
-    final RegExp regex = RegExp(
-      r'^(https?|ftp):\/\/[^\s\/$.?#].[^\s]*$',
-    );
-    return regex.hasMatch(url);
+  static bool isValidUrl(String s) {
+    final Uri? u = Uri.tryParse(s.trim());
+    if (u == null) {
+      return false;
+    }
+    final bool okScheme =
+        u.scheme == 'http' || u.scheme == 'https' || u.scheme == 'ftp';
+    return okScheme && u.hasAuthority;
   }
 
   /// Converts a JSON string to a list of strings.
@@ -167,18 +237,44 @@ class Utils extends EntityUtil {
     return json == true;
   }
 
-  /// Converts a dynamic value to a list of `Map<String, dynamic>`.
+  /// Convert a dynamic value into `List<Map<String, dynamic>>`.
   ///
-  /// - [json]: The dynamic value to convert.
-  /// - Returns: A list of maps, or an empty list if the conversion fails.
+  /// Accepts a `List` whose items can be:
+  /// - `Map<String, dynamic>` (kept as-is)
+  /// - raw `Map` with dynamic keys (keys normalized to `String`)
+  ///
+  /// Returns an empty list if the input is not a `List`.
+  ///
+  /// Example:
+  /// ```dart
+  /// void main() {
+  ///   final List<dynamic> raw = [
+  ///     {'a': 1},
+  ///     <dynamic, dynamic>{'b': 2}, // dynamic keys
+  ///     'ignored',
+  ///   ];
+  ///   final List<Map<String, dynamic>> out = Utils.listFromDynamic(raw);
+  ///   print(out); // [{a: 1}, {b: 2}]
+  /// }
+  /// ```
   static List<Map<String, dynamic>> listFromDynamic(dynamic json) {
-    if (json is List) {
-      return json
-          .whereType<Map<String, dynamic>>()
-          .cast<Map<String, dynamic>>()
-          .toList();
+    if (json is! List) {
+      return <Map<String, dynamic>>[];
     }
-    return <Map<String, dynamic>>[];
+
+    final List<Map<String, dynamic>> out = <Map<String, dynamic>>[];
+    for (final dynamic e in json) {
+      if (e is Map<String, dynamic>) {
+        out.add(e);
+      } else if (e is Map) {
+        final Map<String, dynamic> m = <String, dynamic>{};
+        e.forEach((dynamic k, dynamic v) {
+          m['$k'] = v;
+        });
+        out.add(m);
+      }
+    }
+    return out;
   }
 
   /// Converts a dynamic value to an integer.
@@ -218,13 +314,11 @@ class Utils extends EntityUtil {
       return 0;
     }
 
-    // Try int directly first.
     final int? i = int.tryParse(cleaned);
     if (i != null) {
       return i;
     }
 
-    // Fallback: parse as double, then truncate.
     final double? d = double.tryParse(cleaned);
     if (d == null || d.isNaN || d.isInfinite) {
       return 0;
@@ -298,22 +392,17 @@ class Utils extends EntityUtil {
       return null;
     }
 
-    // Replace non-breaking spaces and thin spaces commonly used as thousands separators.
     s = s
         .replaceAll('\u00A0', ' ')
         .replaceAll('\u202F', ' ')
         .replaceAll('\u2009', ' ')
         .trim();
 
-    // Early parse for plain scientific notation or clean numbers.
-    // If this succeeds, prefer the fast path.
     if (double.tryParse(s) != null || int.tryParse(s) != null) {
       return s;
     }
 
-    // Remove currency/exotic symbols but keep digits, signs, separators, exponent chars, and spaces.
-    // We'll decide later which separator is decimal.
-    const String keptCharsPattern = r'[0-9eE\+\-\,\.\s]';
+    const String keptCharsPattern = r'[0-9eE+\-.,\s]';
     final String stripped = s.split('').where((String ch) {
       return RegExp(keptCharsPattern).hasMatch(ch);
     }).join();
@@ -323,69 +412,52 @@ class Utils extends EntityUtil {
       return null;
     }
 
-    // Collapse multiple spaces.
     t = t.replaceAll(RegExp(r'\s+'), '');
 
-    // If still trivially parseable, return.
     if (double.tryParse(t) != null || int.tryParse(t) != null) {
       return t;
     }
 
-    // Decide decimal separator when both are present.
     final int lastDot = t.lastIndexOf('.');
     final int lastComma = t.lastIndexOf(',');
 
     if (lastDot >= 0 && lastComma >= 0) {
-      // Use the last one as decimal; drop the other as thousands.
       final bool commaIsDecimal = lastComma > lastDot;
       if (commaIsDecimal) {
-        // Remove all dots (thousands), then convert comma to dot.
         t = t.replaceAll('.', '');
         t = t.replaceAll(',', '.');
       } else {
-        // Remove all commas (thousands), keep dots as decimal.
         t = t.replaceAll(',', '');
       }
     } else if (lastComma >= 0) {
-      // Only comma present. If multiple commas → thousands; else decimal.
       final int count = RegExp(',').allMatches(t).length;
       if (count > 1) {
-        t = t.replaceAll(',', ''); // likely thousands separators
+        t = t.replaceAll(',', '');
       } else {
-        t = t.replaceAll(',', '.'); // decimal comma → dot
+        t = t.replaceAll(',', '.');
       }
     } else if (lastDot >= 0) {
-      // Only dot present. If multiple dots → thousands; else decimal.
       final int count = RegExp(r'\.').allMatches(t).length;
       if (count > 1) {
-        t = t.replaceAll('.', ''); // likely thousands
+        t = t.replaceAll('.', '');
       }
-      // else: leave single dot as decimal
     }
 
-    // Final safety pass: keep only one leading sign, digits, one dot for decimal,
-    // and exponent part if any.
-    // Split exponent if present to prevent multiple dots in mantissa+exponent.
     String mantissa = t;
     String exponent = '';
-    final Match? expMatch =
-        RegExp(r'([eE][\+\-]?\d+)$').firstMatch(t); // exponent at end
+    final Match? expMatch = RegExp(r'([eE][+-]?\d+)$').firstMatch(t);
     if (expMatch != null) {
-      exponent = expMatch.group(1)!; // like e-3
+      exponent = expMatch.group(1)!;
       mantissa = t.substring(0, expMatch.start);
     }
 
-    // Remove all but digits, sign, and dot in mantissa.
-    // Keep only the first sign (if at start) and the first dot.
     String sign = '';
     if (mantissa.startsWith('+') || mantissa.startsWith('-')) {
       sign = mantissa[0];
       mantissa = mantissa.substring(1);
     }
-    // Remove everything not digit or dot
-    mantissa = mantissa.replaceAll(RegExp(r'[^0-9\.]'), '');
+    mantissa = mantissa.replaceAll(RegExp(r'[^0-9.]'), '');
 
-    // Keep only first dot
     final int firstDotIdx = mantissa.indexOf('.');
     if (firstDotIdx >= 0) {
       final String before = mantissa.substring(0, firstDotIdx + 1);

--- a/test/domain/financial/financial_movement_test.dart
+++ b/test/domain/financial/financial_movement_test.dart
@@ -75,7 +75,7 @@ void main() {
       expect(
         movementString,
         'FinancialMovementModel(id: fm001, amount: 1000, date: $testDate, '
-        'concept: "Salary", category: "Income", createdAt: $createdAt)',
+        'concept: "Salary", category: "Income", createdAt: $createdAt, mathPrecision: ${FinancialMovementModel.defaultMathPrecision})',
       );
     });
 
@@ -248,16 +248,19 @@ void main() {
     });
 
     test('throws assertion error when decimalAmount is negative', () {
+      final FinancialMovementModel decimalFinancial =
+          FinancialMovementModel.fromDecimal(
+        id: 'tx004',
+        decimalAmount: -5.0,
+        date: DateTime(2024, 07, 20),
+        concept: 'Invalid',
+        category: 'Negative',
+        createdAt: DateTime(2024, 07, 25),
+      );
+
       expect(
-        () => FinancialMovementModel.fromDecimal(
-          id: 'tx004',
-          decimalAmount: -5.0,
-          date: DateTime(2024, 07, 20),
-          concept: 'Invalid',
-          category: 'Negative',
-          createdAt: DateTime(2024, 07, 25),
-        ),
-        throwsA(isA<AssertionError>()),
+        decimalFinancial.amount,
+        greaterThan(0),
       );
     });
 
@@ -273,6 +276,282 @@ void main() {
 
       expect(model.amount, 9991235); // Rounded from 9991234.5678
       expect(model.decimalAmount, closeTo(999.1235, 0.0001));
+    });
+  });
+
+  group('FinancialMovementModel — Constructor', () {
+    test('Given amount >= 0 When construct Then succeeds', () {
+      final FinancialMovementModel model = FinancialMovementModel(
+        id: 'a',
+        amount: 0,
+        date: DateTime(2025),
+        concept: 'Init',
+        category: 'Income',
+        createdAt: DateTime(2025),
+        mathPrecision: 2,
+      );
+      expect(model.amount, 0);
+      expect(model.mathPrecision, 2);
+    });
+  });
+
+  group('fromDecimal', () {
+    test('Given 12.3456@precision4 When fromDecimal Then amount=123456', () {
+      final FinancialMovementModel m = FinancialMovementModel.fromDecimal(
+        id: 'x',
+        decimalAmount: 12.3456,
+        date: DateTime(2025),
+        concept: 'C',
+        category: 'Income',
+        createdAt: DateTime(2025),
+      );
+      expect(m.amount, 123456);
+      expect(m.decimalAmount, closeTo(12.3456, 1e-9));
+    });
+  });
+
+  group('JSON round-trip', () {
+    test('Given model When toJson->fromJson Then equals original', () {
+      final FinancialMovementModel original = FinancialMovementModel(
+        id: 'id1',
+        amount: 1234,
+        date: DateTime(2025, 1, 1, 12, 30),
+        concept: 'Groceries',
+        detailedDescription: 'Local store',
+        category: 'Expense',
+        createdAt: DateTime(2025, 1, 2, 8),
+        mathPrecision: 2,
+      );
+      final FinancialMovementModel copy =
+          FinancialMovementModel.fromJson(original.toJson());
+      expect(copy, equals(original));
+      expect(copy.mathPrecision, 2);
+    });
+  });
+
+  group('Equality & hashCode', () {
+    test('Given same amount but different precision Then not equal', () {
+      final FinancialMovementModel a = FinancialMovementModel(
+        id: 'x',
+        amount: 1000,
+        date: DateTime(2025),
+        concept: 'C',
+        category: 'Income',
+        createdAt: DateTime(2025),
+        mathPrecision: 2,
+      );
+      final FinancialMovementModel b = a.copyWith(mathPrecision: 4);
+      expect(a == b, isFalse);
+      expect(a.hashCode == b.hashCode, isFalse);
+    });
+  });
+
+  group('copyWith', () {
+    test('Given base When copyWith amount Then returns new with updated field',
+        () {
+      final FinancialMovementModel base = FinancialMovementModel(
+        id: 'i',
+        amount: 1,
+        date: DateTime(2025),
+        concept: 'C',
+        category: 'Income',
+        createdAt: DateTime(2025),
+      );
+      final FinancialMovementModel c =
+          base.copyWith(amount: 2, mathPrecision: 3);
+      expect(c.amount, 2);
+      expect(c.mathPrecision, 3);
+      expect(c.id, base.id);
+    });
+  });
+
+  group('FinancialMovementModel — Normalización de signo', () {
+    test(
+      'Given decimalAmount negativo '
+      'When se construye con fromDecimal '
+      'Then amount es no-negativo y coincide con |decimal| escalado',
+      () {
+        // Arrange
+        const int precision = FinancialMovementModel.defaultMathPrecision;
+        const double decimalAmount = -12.34;
+        final DateTime now = DateTime(2025);
+
+        // Act
+        final FinancialMovementModel m = FinancialMovementModel.fromDecimal(
+          id: 'neg-dec',
+          decimalAmount: decimalAmount,
+          date: now,
+          concept: 'Test',
+          category: 'Expense',
+          createdAt: now,
+        );
+
+        // Assert
+        expect(m.amount, isNonNegative);
+        expect(m.decimalAmount, closeTo(decimalAmount.abs(), 1e-9));
+        expect(m.mathPrecision, precision);
+      },
+    );
+
+    test(
+      'Given JSON con amount negativo '
+      'When fromJson '
+      'Then amount se normaliza a no-negativo',
+      () {
+        // Arrange
+        final DateTime date = DateTime(2025, 1, 2, 10, 30);
+        final DateTime created = DateTime(2025, 1, 3, 8);
+        final Map<String, dynamic> json = <String, dynamic>{
+          FinancialMovementEnum.id.name: 'neg-json',
+          FinancialMovementEnum.amount.name: -1234,
+          FinancialMovementEnum.date.name: DateUtils.dateTimeToString(date),
+          FinancialMovementEnum.concept.name: 'Test',
+          FinancialMovementEnum.detailedDescription.name: 'Desc',
+          FinancialMovementEnum.category.name: 'Expense',
+          FinancialMovementEnum.createdAt.name:
+              DateUtils.dateTimeToString(created),
+          FinancialMovementModel.mathPrecisionKey:
+              FinancialMovementModel.defaultMathPrecision,
+        };
+
+        // Act
+        final FinancialMovementModel m = FinancialMovementModel.fromJson(json);
+
+        // Assert
+        expect(m.amount, 1234);
+        expect(
+          m.decimalAmount,
+          closeTo(
+            1234 / FinancialMovementModel.getFactor(m.mathPrecision),
+            1e-9,
+          ),
+        );
+      },
+    );
+
+    test(
+      'Given instancia válida '
+      'When copyWith con amount negativo '
+      'Then amount resultante es no-negativo',
+      () {
+        // Arrange
+        final FinancialMovementModel base = FinancialMovementModel.fromDecimal(
+          id: 'copy-neg',
+          decimalAmount: 10.00,
+          date: DateTime(2025),
+          concept: 'Base',
+          category: 'Income',
+          createdAt: DateTime(2025),
+          precision: 2,
+        );
+
+        // Act
+        final FinancialMovementModel updated = base.copyWith(amount: -999);
+
+        // Assert
+        expect(updated.amount, 999);
+        expect(updated.decimalAmount, closeTo(9.99, 1e-9));
+      },
+    );
+
+    test(
+      'Given instancia con amount positivo '
+      'When toJson '
+      'Then el amount serializado es no-negativo (sin alterar el valor)',
+      () {
+        // Arrange
+        final FinancialMovementModel m = FinancialMovementModel.fromDecimal(
+          id: 'tojson-pos',
+          decimalAmount: -7.89,
+          date: DateTime(2025),
+          concept: 'Serialize',
+          category: 'Income',
+          createdAt: DateTime(2025),
+          precision: 2,
+        );
+
+        // Act
+        final Map<String, dynamic> json = m.toJson();
+
+        // Assert
+        expect(json[FinancialMovementEnum.amount.name], isNonNegative);
+        expect(json[FinancialMovementEnum.amount.name], m.amount);
+      },
+    );
+    test(
+      'Given JSON completo con amount negativo '
+      'When fromJson '
+      'Then amount se normaliza a positivo y conserva el resto de campos',
+      () {
+        // Arrange
+        final DateTime date = DateTime(2025, 1, 2, 10, 30);
+        final DateTime createdAt = DateTime(2025, 1, 3, 8);
+        const int precision = FinancialMovementModel.defaultMathPrecision;
+
+        final Map<String, dynamic> json = <String, dynamic>{
+          FinancialMovementEnum.id.name: 'neg-json-full',
+          FinancialMovementEnum.amount.name: -1234,
+          FinancialMovementEnum.date.name: DateUtils.dateTimeToString(date),
+          FinancialMovementEnum.concept.name: 'Compra',
+          FinancialMovementEnum.detailedDescription.name: 'Supermercado',
+          FinancialMovementEnum.category.name: 'Expense',
+          FinancialMovementEnum.createdAt.name:
+              DateUtils.dateTimeToString(createdAt),
+          FinancialMovementModel.mathPrecisionKey: precision,
+        };
+
+        // Act
+        final FinancialMovementModel m = FinancialMovementModel.fromJson(json);
+
+        // Assert
+        expect(m.id, 'neg-json-full');
+        expect(m.amount, 1234, reason: 'Debe normalizar el signo a positivo');
+        expect(m.date, date);
+        expect(m.concept, 'Compra');
+        expect(m.detailedDescription, 'Supermercado');
+        expect(m.category, 'Expense');
+        expect(m.createdAt, createdAt);
+        expect(m.mathPrecision, precision);
+
+        // Y el valor decimal debe coincidir con |amount| / 10^precision
+        final double esperado =
+            1234 / FinancialMovementModel.getFactor(precision);
+        expect(m.decimalAmount, closeTo(esperado, 1e-9));
+      },
+    );
+    test('fromJson: sin mathPrecision usa default', () {
+      final Map<String, dynamic> json = <String, dynamic>{
+        FinancialMovementEnum.id.name: 'id',
+        FinancialMovementEnum.amount.name: 100,
+        FinancialMovementEnum.date.name:
+            DateUtils.dateTimeToString(DateTime(2025)),
+        FinancialMovementEnum.concept.name: 'C',
+        FinancialMovementEnum.detailedDescription.name: '',
+        FinancialMovementEnum.category.name: 'Income',
+        FinancialMovementEnum.createdAt.name:
+            DateUtils.dateTimeToString(DateTime(2025)),
+        // sin mathPrecisionKey
+      };
+      final FinancialMovementModel m = FinancialMovementModel.fromJson(json);
+      expect(m.mathPrecision, FinancialMovementModel.defaultMathPrecision);
+    });
+
+    test('fromJson: con mathPrecision explícito respeta el valor (incluido 0)',
+        () {
+      final Map<String, dynamic> json = <String, dynamic>{
+        FinancialMovementEnum.id.name: 'id',
+        FinancialMovementEnum.amount.name: 100,
+        FinancialMovementEnum.date.name:
+            DateUtils.dateTimeToString(DateTime(2025)),
+        FinancialMovementEnum.concept.name: 'C',
+        FinancialMovementEnum.detailedDescription.name: '',
+        FinancialMovementEnum.category.name: 'Income',
+        FinancialMovementEnum.createdAt.name:
+            DateUtils.dateTimeToString(DateTime(2025)),
+        FinancialMovementModel.mathPrecisionKey: 0, // permitido
+      };
+      final FinancialMovementModel m = FinancialMovementModel.fromJson(json);
+      expect(m.mathPrecision, 0);
     });
   });
 }

--- a/test/domain/financial/ledger_model_test.dart
+++ b/test/domain/financial/ledger_model_test.dart
@@ -71,4 +71,444 @@ void main() {
       expect(str.contains(ledger.decimalBalance.toString()), isTrue);
     });
   });
+
+  group('LedgerModel — fromJson & toJson', () {
+    test(
+        'Given JSON válido When fromJson Then crea listas inmutables y calcula balances',
+        () {
+      // Arrange
+      final Map<String, dynamic> json = <String, dynamic>{
+        LedgerEnum.nameOfLedger.name: 'Primary',
+        LedgerEnum.incomeLedger.name: <Map<String, dynamic>>[
+          FinancialMovementModel.fromDecimal(
+            id: 'i1',
+            decimalAmount: 10.50,
+            date: DateTime(2025),
+            concept: 'Salary',
+            category: 'Income',
+            createdAt: DateTime(2025),
+            precision: 2,
+          ).toJson(),
+        ],
+        LedgerEnum.expenseLedger.name: <Map<String, dynamic>>[
+          FinancialMovementModel.fromDecimal(
+            id: 'e1',
+            decimalAmount: 3.25,
+            date: DateTime(2025, 1, 2),
+            concept: 'Groceries',
+            category: 'Expense',
+            createdAt: DateTime(2025, 1, 2),
+            precision: 2,
+          ).toJson(),
+        ],
+      };
+
+      // Act
+      final LedgerModel ledger = LedgerModel.fromJson(json);
+
+      // Assert (inmutabilidad de colecciones)
+      expect(
+        () => ledger.incomeLedger.add(defaultMovement),
+        throwsUnsupportedError,
+      );
+      expect(
+        () => ledger.expenseLedger.add(defaultMovement),
+        throwsUnsupportedError,
+      );
+
+      // Assert (balance entero y decimal)
+      // 10.50 - 3.25 = 7.25
+      expect(ledger.decimalBalance, closeTo(7.25, 1e-9));
+      // Para el balance entero dependemos de precisión de cada movimiento (2):
+      // 1050 - 325 = 725
+      expect(ledger.balance, 725);
+
+      // Round-trip
+      final Map<String, dynamic> back = ledger.toJson();
+      final LedgerModel again = LedgerModel.fromJson(back);
+      expect(again, equals(ledger));
+    });
+  });
+
+  group('LedgerModel — copyWith', () {
+    test('Given nuevas listas When copyWith Then envuelve en unmodifiable', () {
+      // Arrange
+      final LedgerModel base = LedgerModel.fromJson(<String, dynamic>{
+        LedgerEnum.nameOfLedger.name: 'Base',
+        LedgerEnum.incomeLedger.name: const <Map<String, dynamic>>[],
+        LedgerEnum.expenseLedger.name: const <Map<String, dynamic>>[],
+      });
+
+      final List<FinancialMovementModel> incomes = <FinancialMovementModel>[
+        FinancialMovementModel.fromDecimal(
+          id: 'i2',
+          decimalAmount: 1.00,
+          date: DateTime(2025, 1, 3),
+          concept: 'Gift',
+          category: 'Income',
+          createdAt: DateTime(2025, 1, 3),
+          precision: 2,
+        ),
+      ];
+
+      // Act
+      final LedgerModel updated = base.copyWith(incomeLedger: incomes);
+
+      // Assert
+      expect(updated.incomeLedger.length, 1);
+      expect(
+        () => updated.incomeLedger.add(defaultMovement),
+        throwsUnsupportedError,
+      );
+
+      // Asegurar que la lista original externa puede mutar sin afectar al ledger
+      incomes.add(defaultMovement);
+      expect(
+        updated.incomeLedger.length,
+        1,
+        reason: 'Debe permanecer inmutable',
+      );
+    });
+  });
+
+  group('LedgerModel — equality & hashCode', () {
+    test(
+        'Given dos libros con mismas entradas (mismo orden) Then son iguales y hash coincide',
+        () {
+      // Arrange
+      final FinancialMovementModel i = FinancialMovementModel.fromDecimal(
+        id: 'i3',
+        decimalAmount: 2.00,
+        date: DateTime(2025, 1, 4),
+        concept: 'Sale',
+        category: 'Income',
+        createdAt: DateTime(2025, 1, 4),
+        precision: 2,
+      );
+      final FinancialMovementModel e = FinancialMovementModel.fromDecimal(
+        id: 'e3',
+        decimalAmount: 1.50,
+        date: DateTime(2025, 1, 5),
+        concept: 'Food',
+        category: 'Expense',
+        createdAt: DateTime(2025, 1, 5),
+        precision: 2,
+      );
+
+      final LedgerModel a = LedgerModel(
+        nameOfLedger: 'Eq',
+        incomeLedger: List<FinancialMovementModel>.unmodifiable(
+          <FinancialMovementModel>[i],
+        ),
+        expenseLedger: List<FinancialMovementModel>.unmodifiable(
+          <FinancialMovementModel>[e],
+        ),
+      );
+      final LedgerModel b = LedgerModel(
+        nameOfLedger: 'Eq',
+        incomeLedger: List<FinancialMovementModel>.unmodifiable(
+          <FinancialMovementModel>[i],
+        ),
+        expenseLedger: List<FinancialMovementModel>.unmodifiable(
+          <FinancialMovementModel>[e],
+        ),
+      );
+
+      // Assert
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+    });
+
+    test('Given mismas entradas pero distinto orden Then no son iguales', () {
+      // Arrange
+      final FinancialMovementModel i1 = FinancialMovementModel.fromDecimal(
+        id: 'iA',
+        decimalAmount: 1.00,
+        date: DateTime(2025),
+        concept: 'A',
+        category: 'Income',
+        createdAt: DateTime(2025),
+        precision: 2,
+      );
+      final FinancialMovementModel i2 = FinancialMovementModel.fromDecimal(
+        id: 'iB',
+        decimalAmount: 2.00,
+        date: DateTime(2025, 1, 2),
+        concept: 'B',
+        category: 'Income',
+        createdAt: DateTime(2025, 1, 2),
+        precision: 2,
+      );
+
+      final LedgerModel a = LedgerModel(
+        nameOfLedger: 'Order',
+        incomeLedger: List<FinancialMovementModel>.unmodifiable(
+          <FinancialMovementModel>[i1, i2],
+        ),
+        expenseLedger: const <FinancialMovementModel>[],
+      );
+      final LedgerModel b = LedgerModel(
+        nameOfLedger: 'Order',
+        incomeLedger: List<FinancialMovementModel>.unmodifiable(
+          <FinancialMovementModel>[i2, i1],
+        ),
+        expenseLedger: const <FinancialMovementModel>[],
+      );
+
+      // Assert
+      expect(a == b, isFalse);
+    });
+  });
+
+  group('LedgerModel — constructor principal (riesgo documentado)', () {
+    test(
+        'Given listas MUTABLES al ctor Then el modelo puede ser mutable externamente (documentado)',
+        () {
+      // Este test ilustra el riesgo (no es un hard-fail): el ctor principal no envuelve.
+      final List<FinancialMovementModel> incomes = <FinancialMovementModel>[];
+      final LedgerModel ledger = LedgerModel(
+        nameOfLedger: 'MutableCtor',
+        incomeLedger: incomes,
+        expenseLedger: const <FinancialMovementModel>[],
+      );
+
+      // Mutación externa
+      incomes.add(defaultMovement);
+
+      // El ledger "ve" el cambio porque comparte referencia.
+      expect(
+        ledger.incomeLedger.length,
+        1,
+        reason: 'Constructor principal no envuelve; riesgo documentado.',
+      );
+    });
+  });
+
+  group('LedgerModel.fromJson — Formas válidas de JSON', () {
+    test(
+      'Given listas bien formadas de Map<String,dynamic> '
+      'When fromJson '
+      'Then crea LedgerModel con balances correctos',
+      () {
+        // Arrange
+        final Map<String, dynamic> json = <String, dynamic>{
+          LedgerEnum.nameOfLedger.name: 'Primary',
+          LedgerEnum.incomeLedger.name: <Map<String, dynamic>>[
+            FinancialMovementModel.fromDecimal(
+              id: 'i1',
+              decimalAmount: 100.00,
+              date: DateTime(2025),
+              concept: 'Salary',
+              category: 'Income',
+              createdAt: DateTime(2025),
+              precision: 2,
+            ).toJson(),
+          ],
+          LedgerEnum.expenseLedger.name: <Map<String, dynamic>>[
+            FinancialMovementModel.fromDecimal(
+              id: 'e1',
+              decimalAmount: 30.50,
+              date: DateTime(2025, 1, 2),
+              concept: 'Groceries',
+              category: 'Expense',
+              createdAt: DateTime(2025, 1, 2),
+              precision: 2,
+            ).toJson(),
+          ],
+        };
+
+        // Act
+        final LedgerModel ledger = LedgerModel.fromJson(json);
+
+        // Assert
+        expect(ledger.nameOfLedger, 'Primary');
+        expect(ledger.incomeLedger.length, 1);
+        expect(ledger.expenseLedger.length, 1);
+        expect(ledger.decimalBalance, closeTo(69.50, 1e-9));
+        expect(ledger.balance, 6950);
+      },
+    );
+
+    test(
+      'Given listas de List<dynamic> mezclando Map y no-Map '
+      'When fromJson '
+      'Then ignora los no-Map y parsea solo los Map válidos',
+      () {
+        // Arrange
+        final Map<String, dynamic> json = <String, dynamic>{
+          LedgerEnum.nameOfLedger.name: 'Mixed',
+          LedgerEnum.incomeLedger.name: <dynamic>[
+            // válido
+            FinancialMovementModel.fromDecimal(
+              id: 'i1',
+              decimalAmount: 10.00,
+              date: DateTime(2025, 1, 3),
+              concept: 'Gift',
+              category: 'Income',
+              createdAt: DateTime(2025, 1, 3),
+              precision: 2,
+            ).toJson(),
+            // ruido: no-Map
+            42,
+            'string',
+            null,
+            // válido con claves adicionales (deben ser ignoradas por el modelo)
+            <String, dynamic>{
+              ...FinancialMovementModel.fromDecimal(
+                id: 'i2',
+                decimalAmount: 5.50,
+                date: DateTime(2025, 1, 4),
+                concept: 'Tip',
+                category: 'Income',
+                createdAt: DateTime(2025, 1, 4),
+                precision: 2,
+              ).toJson(),
+              'extra': 'ignore-me',
+            },
+          ],
+          LedgerEnum.expenseLedger.name: <dynamic>[
+            // válido
+            FinancialMovementModel.fromDecimal(
+              id: 'e1',
+              decimalAmount: 3.00,
+              date: DateTime(2025, 1, 5),
+              concept: 'Snacks',
+              category: 'Expense',
+              createdAt: DateTime(2025, 1, 5),
+              precision: 2,
+            ).toJson(),
+            // ruido: lista dentro de lista
+            <int>[1, 2, 3],
+          ],
+        };
+
+        // Act
+        final LedgerModel ledger = LedgerModel.fromJson(json);
+
+        // Assert: solo debe contar 2 ingresos válidos y 1 egreso válido
+        expect(ledger.incomeLedger.length, 2);
+        expect(ledger.expenseLedger.length, 1);
+
+        // (10.00 + 5.50) - 3.00 = 12.50
+        expect(ledger.decimalBalance, closeTo(12.50, 1e-9));
+        expect(ledger.balance, 1250);
+      },
+    );
+
+    test(
+      'Given incomeLedger/expenseLedger ausentes (null) '
+      'When fromJson '
+      'Then crea listas vacías y balance en 0',
+      () {
+        // Arrange
+        final Map<String, dynamic> json = <String, dynamic>{
+          LedgerEnum.nameOfLedger.name: 'Empty',
+          // Sin incomeLedger
+          // Sin expenseLedger
+        };
+
+        // Act
+        final LedgerModel ledger = LedgerModel.fromJson(json);
+
+        // Assert
+        expect(ledger.incomeLedger, isEmpty);
+        expect(ledger.expenseLedger, isEmpty);
+        expect(ledger.balance, 0);
+        expect(ledger.decimalBalance, 0.0);
+      },
+    );
+
+    test(
+      'Given movimientos con diferentes precisiones '
+      'When fromJson '
+      'Then balance entero/decimal respeta cada mathPrecision individual',
+      () {
+        // Arrange
+        // i1: 12.3456 @ p=4 => 123456
+        // i2:  1.20   @ p=2 =>   120
+        // e1:  0.005  @ p=3 =>     5
+        final Map<String, dynamic> json = <String, dynamic>{
+          LedgerEnum.nameOfLedger.name: 'Precisions',
+          LedgerEnum.incomeLedger.name: <Map<String, dynamic>>[
+            FinancialMovementModel.fromDecimal(
+              id: 'i1',
+              decimalAmount: 12.3456,
+              date: DateTime(2025, 1, 6),
+              concept: 'A',
+              category: 'Income',
+              createdAt: DateTime(2025, 1, 6),
+            ).toJson(),
+            FinancialMovementModel.fromDecimal(
+              id: 'i2',
+              decimalAmount: 1.20,
+              date: DateTime(2025, 1, 6),
+              concept: 'B',
+              category: 'Income',
+              createdAt: DateTime(2025, 1, 6),
+              precision: 2,
+            ).toJson(),
+          ],
+          LedgerEnum.expenseLedger.name: <Map<String, dynamic>>[
+            FinancialMovementModel.fromDecimal(
+              id: 'e1',
+              decimalAmount: 0.005,
+              date: DateTime(2025, 1, 7),
+              concept: 'Fee',
+              category: 'Expense',
+              createdAt: DateTime(2025, 1, 7),
+              precision: 3,
+            ).toJson(),
+          ],
+        };
+
+        // Act
+        final LedgerModel ledger = LedgerModel.fromJson(json);
+
+        // Assert (decimal): 12.3456 + 1.20 - 0.005 = 13.5406
+        expect(ledger.decimalBalance, closeTo(13.5406, 1e-9));
+
+        // Assert (entero): depende de MoneyUtils.totalAmount(...)
+        // que suma enteros ya escalados por movimiento y resta los de egresos.
+        // Aquí verificamos consistencia con toJson->fromJson (round-trip).
+        final LedgerModel again = LedgerModel.fromJson(ledger.toJson());
+        expect(again.balance, ledger.balance);
+        expect(again.decimalBalance, closeTo(ledger.decimalBalance, 1e-9));
+      },
+    );
+
+    test(
+      'Given amount negativo dentro de items (permitido por contrato de movimiento) '
+      'When fromJson '
+      'Then normaliza a positivo por política del modelo de movimiento',
+      () {
+        // Arrange: forzamos un item con amount negativo en el JSON bruto
+        final FinancialMovementModel base = FinancialMovementModel.fromDecimal(
+          id: 'i1',
+          decimalAmount: 5.00,
+          date: DateTime(2025, 1, 8),
+          concept: 'Base',
+          category: 'Income',
+          createdAt: DateTime(2025, 1, 8),
+          precision: 2,
+        );
+        final Map<String, dynamic> badIncome = <String, dynamic>{
+          ...base.toJson(),
+          FinancialMovementEnum.amount.name: -base.amount, // < 0
+        };
+
+        final Map<String, dynamic> json = <String, dynamic>{
+          LedgerEnum.nameOfLedger.name: 'Negatives',
+          LedgerEnum.incomeLedger.name: <Map<String, dynamic>>[badIncome],
+          LedgerEnum.expenseLedger.name: <Map<String, dynamic>>[],
+        };
+
+        // Act
+        final LedgerModel ledger = LedgerModel.fromJson(json);
+
+        // Assert: el movimiento interno se normaliza (por FinancialMovementModel.fromJson)
+        expect(ledger.incomeLedger.first.amount, base.amount);
+        expect(ledger.decimalBalance, closeTo(5.00, 1e-9));
+      },
+    );
+  });
 }


### PR DESCRIPTION
* publish_1.27.0 (#68)

* feat(@albertjjimenezp): mejora y amplía la documentación de BlocGeneral y BlocModule con ejemplos de uso y detalles sobre el ciclo de vida.

* Bump version to 1.20.0

* feat(@albertjjimenezp): add project structure guide for jocaagura_domain

* Bump version to 1.20.1

* fix: rename codeql.yml to codeql.txt and disable due to scanning issues

* Bump version to 1.20.2

* feat: Improve - ISSUE 21 implement FakeServiceWsDatabase for WebSocket-based NoSQL operations

* feat: Improve - ISSUE 21 implement FakeServiceWsDatabase for WebSocket-based NoSQL operations 2

* feat: Improve - ISSUE 21 implement FakeServiceWsDatabase for WebSocket-based NoSQL finished

* feat: Add FakeServiceSession for development and testing of user session management initial

* feat: Add FakeServiceSession for development and testing of user session management initial

* feat: Add FakeServiceLocation for development and testing of user Geolocation

* feat: Add FakeServiceGyroscope for development and testing of device gyroscope

* feat: Add FakeServiceNotifications for development and testing of notyifications service

* feat: Add FakeServiceConnectivity for development and testing of connectivity service

* feat: Add FakeServicePreferences for development and testing of preferences service

* feat(@albertjjimenezp): Add fakes services and generic services to jocaagura_domain.dart

* Bump version to 1.21.0

* feat(@albertjjimenezp): Update readme and some minor fixes

* Bump version to 1.21.1

* feat(@albertjjimenezp): Fixed format error into CHANGELOG.md

* Bump version to 1.21.2

* 37 implements migration blocs and services (#38)

* Update package into pub.dev  (#33)

* feat(@albertjjimenezp): mejora y amplía la documentación de BlocGeneral y BlocModule con ejemplos de uso y detalles sobre el ciclo de vida.

* Bump version to 1.20.0

* feat(@albertjjimenezp): add project structure guide for jocaagura_domain

* Bump version to 1.20.1

* fix: rename codeql.yml to codeql.txt and disable due to scanning issues

* Bump version to 1.20.2

* feat: Improve - ISSUE 21 implement FakeServiceWsDatabase for WebSocket-based NoSQL operations

* feat: Improve - ISSUE 21 implement FakeServiceWsDatabase for WebSocket-based NoSQL operations 2

* feat: Improve - ISSUE 21 implement FakeServiceWsDatabase for WebSocket-based NoSQL finished

* feat: Add FakeServiceSession for development and testing of user session management initial

* feat: Add FakeServiceSession for development and testing of user session management initial

* feat: Add FakeServiceLocation for development and testing of user Geolocation

* feat: Add FakeServiceGyroscope for development and testing of device gyroscope

* feat: Add FakeServiceNotifications for development and testing of notyifications service

* feat: Add FakeServiceConnectivity for development and testing of connectivity service

* feat: Add FakeServicePreferences for development and testing of preferences service

* feat(@albertjjimenezp): Add fakes services and generic services to jocaagura_domain.dart

* Bump version to 1.21.0

* feat(@albertjjimenezp): Update readme and some minor fixes

* Bump version to 1.21.1

* feat(@albertjjimenezp): Fixed format error into CHANGELOG.md

* Bump version to 1.21.2

---------



* feat: Implement loading and onboarding BLoCs with responsive design support

* feat: Update changelog

* feat: fixed linter warnings

* Bump version to 1.22.0

* Bump version to 1.23.0

---------



* feat: Implement session management use cases and repository for authentication

* feat: Implement session management use cases and repository for authentication

* Bump version to 1.23.1

* feat: Add WebSocket database repository implementation and related configurations

* fix: dart format on file usecases

* fix: Entity errors

* chore(version): bump to 1.24.0

* Feat: Base entire flow for BlocConnectivity include FakeConnectivity Service

* Feat: Evolution for entire flow for BlocConnectivity include FakeConnectivity Service

* Feat: connectivity_demo_page.dart added detailed dartdoc and user documentation

* Feat: Complete unit testing for Blocconnectivity flow

* Feat: Changelog and linters updated

* Feat: Readme updated

* Feat: Fix conflicts with merge

* chore(version): bump to 1.24.1

* Feat: Add BlocLoading new demo and asynchronous operations

* Feat: Add BlocOnboarding new demo and asynchronous operations

* Feat: BlocResponsive reviewed

* Feat: BlocResponsive readme and page demo instructions added

* Feat: ChangelogUpdated

* chore(version): bump to 1.24.2

* Feat: Changelog and version update and erady for publish 1.25.0

* chore(version): bump to 1.25.0

* refactor(DefaultErrorMapper): use const constructor

Updates all instantiations of `DefaultErrorMapper` to use its `const` constructor. This allows Dart to canonicalize the instance at compile time, reducing memory overhead and improving instantiation speed.

* feat(BlocSession): add stream and stateOrDefault getters

- Introduced `stream` as an alias for `sessionStream`.
- Added `stateOrDefault` for a synchronous snapshot of the current session state.
- Implemented tests covering:
  - Equivalence of `stream` and `sessionStream` emissions.
  - Default `Unauthenticated` state when no session exists.
  - Correct `Authenticated` state reflecting `currentUser`.
  - Snapshot semantics of `stateOrDefault` (no new emissions).
  - Basic stream subscription behavior.
  - Post-`dispose()` behavior (last state emitted, then stream closes).

* feat(BlocSession): add post-dispose policies and refine state management

- Introduced `PostDisposePolicy` enum to control getter behavior after `dispose()`:
  - `throwStateError` (default): strict, throws `StateError` on access.
  - `returnLastSnapshot`: lenient, returns last cached values.
  - `returnSessionError`: lenient, `state` returns `SessionError`, helpers safe.
- Updated getters (`state`, `stateOrDefault`, `currentUser`, `isAuthenticated`, `sessionStream`) to respect the configured policy.
- Improved `SessionState` subclasses with detailed DartDocs on purpose and transitions.
- Added DartDocs for policies, states, and getters, clarifying post-dispose behavior.
- Expanded tests:
  - `refreshSession()` failure results in `SessionError`.
  - `boot()` is idempotent.
  - New group `BlocSession: dispose & postDisposePolicy` covering:
    - Getter behavior after `dispose()`.
    - Public methods after `dispose()` (must throw).
    - Stream behavior for late subscribers.
    - No repository reflection after `dispose()`.
- Minor cleanup: ensure `_ensureNotDisposed` is invoked in public methods.

* refactor: Standardize error handling and JSON processing in gateways

- Updated `GatewayConnectivity` to consistently use `json` for raw payloads.
- Aligned `GatewayWsDatabase` to use `Either` with `ErrorItem` for unified success/failure representation.

* refactor: Relocate example pages to main.dart

This commit moves the following example page implementations from their individual files into `example/lib/main.dart`:
- `BlocLoadingDemoPage`
- `BlocOnboardingDemoPage`
- `BlocResponsiveDemoPage`
- `ConnectivityDemoPage`
- `HomePage`
- `SessionDemoPage`
- `WsDatabaseUserDemoPage`

The corresponding individual files have been deleted. The `GatewayWsDatabase` abstract class has also been moved to `main.dart`.

* feat: changelog updated

* patch:format dart code

* fix: flutter analyze fixed

* chore(version): bump to 1.25.1

* feat(workflow): add GitHub Actions for commit validation and linting

Introduced a new GitHub Actions workflow `Validate commits (signed) & linters` that runs on `push` and `pull_request` for all branches. It enforces:

- Commit signing verification.
- Flutter environment setup.
- `flutter pub get` on all `pubspec.yaml` files.
- No usage of `dependency_overrides` in `pubspec.yaml`.
- Dart code formatting via `dart format`.
- Static analysis via `dart analyze` with fatal infos and warnings.

* feat(workflow): add GitHub Actions for commit validation and linting

Introduced a new GitHub Actions workflow `Validate commits (signed) & linters` that runs on `push` and `pull_request` for all branches. It enforces:

- Commit signing verification.
- Flutter environment setup.
- `flutter pub get` on all `pubspec.yaml` files.
- No usage of `dependency_overrides` in `pubspec.yaml`.
- Dart code formatting via `dart format`.
- Static analysis via `dart analyze` with fatal infos and warnings.

* Fix: Update Flutter setup in CI workflow

Changed `flutter-version` and `channel` to `version` for Flutter setup in the GitHub Actions workflow.

* Fix: Activate cache

* Fix: Uses channel not version only

* feat: Add lightweight GitHub Action for commit validation and enhance branch protection rules

* fix: add name for validate commits

* feat(domain): add integer-oriented utilities to ModelVector

- Introduce `ModelVector.fromXY(int x, int y)` factory for convenient creation.
- Add integer-oriented getters `x` and `y` (round policy: .5 away from zero).
- Add `key` property for canonical "x,y" representation in maps/sets.
- Add `copyWithInts({int? x, int? y})` for safe copies with integer overrides.
- Extend DartDoc with examples and clarify rounding policy limitations.
- Add unit tests covering rounding behavior, key stability, copyWithInts, and fromXY.

Bump version to 1.25.3.

* feat: Enhance ModelVector with new features and tests

This commit introduces several enhancements to the `ModelVector` class and adds comprehensive tests.

* feat: Enhance ModelVector with new features and tests

This commit introduces several enhancements to the `ModelVector` class and adds comprehensive tests.

* Fix: Refine commit SHA retrieval in CI workflow

This commit improves the logic for fetching commit SHAs in the `validate_commits_and_lints.yaml` GitHub Actions workflow.

* Fix: Refine commit SHA retrieval in CI workflow

This commit improves the logic for fetching commit SHAs in the `validate_commits_and_lints.yaml` GitHub Actions workflow.

* Fix: Refine commit SHA retrieval in CI workflow

This commit improves the logic for fetching commit SHAs in the `validate_commits_and_lints.yaml` GitHub Actions workflow.

* chore(version): bump to 1.25.2

* Refactor: Enhance numeric parsing in Utils
- Updated CHANGELOG.md to reflect these improvements.

* chore(version): bump to 1.26.0

* test: Add unit tests for OnboardingStep

* refactor(onboarding): enhance OnboardingStep docs and clarify contracts

- Expanded `onEnter` contract:
  - Must not throw; return `Left(ErrorItem)` to stay on current step.
  - Should be fast; heavy work belongs to use cases.
  - `null` implies immediate success.
- Clarified `autoAdvanceAfter`: only effective after a successful `onEnter`.
- Added example covering different `OnboardingStep` configs and `onEnter` outcomes.
- Refined field docs (`title`, `description`, `autoAdvanceAfter`, `onEnter`) for clarity.
- Updated `OnEnterResult` typedef docs to reflect refined contract.

* refactor(onboarding): add JSON serialization and enum for OnboardingState

- Implemented `Model` for JSON serialization/deserialization.
- Introduced `OnboardingStateEnum` to define stable JSON keys.
- Updated docs and examples for better clarity.
- Fixed minor logic error in `ErrorItem.operator==`.

* refactor(onboarding): improve JSON deserialization and ErrorItem equality

- OnboardingState:
  - Enhanced `fromJson` to handle `error` as null, Map, or stringified JSON.
  - Fallback to default `ErrorItem` for unparseable error strings.
- ErrorItem:
  - `hashCode` now uses `Object.hashAllUnordered` for stable map hashing.
  - Removed redundant `hashCode == other.hashCode` check in `==` operator.
- Tests:
  - Added comprehensive unit tests covering:
    - Factories, UI utilities, and `copyWith` behavior.
    - JSON serialization/deserialization (including malformed input).
    - Equality, `hashCode`, `toString`, and status string parsing.

* docs(onboarding): improve OnboardingState DartDocs and JSON contract

- JSON contract:
  - Clarified key stability for `OnboardingStateEnum`.
  - Added semantics for `OnboardingStatus` values.
- OnboardingState class:
  - Documented contracts and responsibilities (immutability, orchestrator validation).
  - Explained JSON parsing resilience and fallback policies.
  - Documented convenience getters `hasStep` and `stepNumber`.
  - Provided JSON round-trip example.
- API docs:
  - Improved DartDocs for constructors, fields, `copyWith`, `toJson`, `==`, `hashCode`, and `toString`.
  - Clarified `copyWith` behavior for `error` (sentinel vs. explicit null).

* docs(onboarding): previous dartdoc

* feat(onboarding): improve BlocOnboarding documentation and contracts

- DartDocs:
  - Expanded `BlocOnboarding` docs with sections on purpose, error handling, concurrency/race-safety, auto-advance, state invariants, error persistence, and a minimal usage example.
  - Added docs for all public methods and properties.
- Internals:
  - Renamed variable in `retryOnEnter` for clarity.
  - Added comments to `_runOnEnterAndMaybeSchedule` and `_scheduleAutoAdvanceIfAny` explaining logic.

* feat(onboarding): add BlocOnboarding tests and refine back navigation

- Added comprehensive unit tests for `BlocOnboarding`:
  - Configuration and startup (empty/non-empty steps).
  - `onEnter` behavior: success, error (`Left`), and exceptions.
  - `retryOnEnter` and `clearError`.
  - `next` and `back` navigation with timer cancellation and state transitions.
  - `currentStep` behavior in multiple states.
  - Race condition guards via epoch mechanism.
  - Terminal states (`skip`, `complete`) preserving errors.
  - `dispose` and its effect on timers.
- Refined `back()`:
  - Prevents auto-advance after navigating back, even if the step has `autoAdvanceAfter`.
  - Ensures more predictable UX; `onEnter` of the previous step still runs.

* Docs: Improve BlocOnboarding documentation

* feat: Add onboarding_example.dart with validation logic

* feat: Add onboarding_example.dart with validation logic

* feat: Add advanced onboarding example and alias

* feat: Update CHANGELOG.md with version 1.26.1 details

This commit updates the CHANGELOG.md file to include the changes for version 1.26.1, released on 2025-09-13.

* chore(version): bump to 1.26.1

* refactor: Introduce AutoAdvancePolicy to BlocOnboarding

This change introduces an `AutoAdvancePolicy` to the `BlocOnboarding` class, allowing for more granular control over when the onboarding flow automatically advances to the next step.

* refactor: Improve ErrorItem model and add tests

This commit enhances the `ErrorItem` model with:
- Improved DartDocs for `ErrorItem`, `ErrorLevelEnum`, and `ErrorItemEnum`, including usage examples and UI guidelines.
- Robust JSON serialization/deserialization with a fallback to `ErrorLevelEnum.systemInfo` for unknown error levels.
- Made the `meta` field in `copyWith` unmodifiable to prevent unintended mutations.

* feat: Introduce AutoAdvancePolicy in BlocOnboarding and enhance ErrorItem

* chore(version): bump to 1.26.2

* feat: Publish 1.27.0 Enhance Onboarding, ErrorItem, and Testing

* chore(version): bump to 1.27.0

---------



* feat(utils): improve type handling in mapFromDynamic/listFromDynamic and add tests

- mapFromDynamic:
  - Handles `Map<dynamic, dynamic>` by normalizing keys to `String`.
  - Improved JSON string decoding (returns empty map for non-object or failures).
  - Updated documentation for clarity.
- listFromDynamic:
  - Processes lists of maps by normalizing keys to `String`.
  - Ignores non-map elements in input list.
  - Updated documentation for clarity.
- Tests:
  - Added extensive unit tests for both methods covering edge cases and normalization.
- Other utils:
  - Minor refactor in `intFromDynamic` and `sanitizeNumberString`.
  - Updated regex in `isEmail` and simplified `isValidUrl` logic.

* refactor(utils): fix spelling of phone number formatting methods

- Added aliases:
  - `getFormattedPhoneNumber` → replaces `getFormatedPhoneNumber`.
  - `getFormattedPhoneNumberAlt` → replaces `getFormatedPhoneNumberAlt`.
- Retained original methods for backward compatibility (logic unchanged).
- Added documentation for new aliases to clarify behavior and contract.

* Refactor: Enhance FinancialMovementModel for robust decimal handling

- Implement scaled integer storage for financial amounts to avoid precision issues, using a `mathPrecision` field.
- Ensure all monetary amounts are stored as non-negative values, with transaction direction (income/expense) determined by the `category` field.
- Update constructors (`fromJson`, `fromDecimal`) and `copyWith` to normalize negative input amounts to their absolute values.
- Add `mathPrecisionKey` for JSON serialization/deserialization to maintain precision fidelity.
- Update `toString`, `equals`, and `hashCode` to include `mathPrecision`.
- Expand unit tests to cover new precision logic, sign normalization, JSON round-trips with precision, and edge cases.

* refactor(model): make LedgerModel immutable and improve JSON handling

- Made `incomeLedger` and `expenseLedger` unmodifiable after creation/copying.
- Updated `fromJson` to parse and create unmodifiable lists.
- Updated `toJson` to ensure correct list serialization.
- Implemented defensive copying in `copyWith` to preserve immutability.
- Added `_listEquals` and `_listHash` for deep equality and hashing of lists.
- Simplified `LedgerEnum` by removing verbose comments.
- Removed redundant comments from constructors and properties.
- Streamlined `toString` method.

* refactor(model): enhance LedgerModel immutability and add detailed tests

- Docs:
  - Expanded Dartdoc for `LedgerModel` (immutability contract, equality/hashing, usage examples).
- Implementation:
  - Ensured `fromJson` and `copyWith` produce unmodifiable lists.
  - Fixed minor nullability issue in `_listHash`.
- Tests:
  - Added round-trip tests for `fromJson`/`toJson` with varied JSON (valid, mixed, missing fields).
  - Verified `copyWith` preserves immutability with new lists.
  - Checked equality (`==`) and `hashCode` consistency, including list order cases.
  - Documented constructor behavior with mutable list inputs.
  - Covered `FinancialMovementModel` integration (decimal precision and negative normalization).

* feat: Update changelog

---------