### PR TITLE
Dev/modelitem and other models for storemodel (#110)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,53 @@
 This document follows the guidelines of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.31.2] - 2025-10-18
+
+### Added
+
+- **Domain – Productos y precios**
+  - `ModelItem`: entidad mínima y extensible (id, name, description, `type: ModelCategory`,
+    `price: ModelPrice`, `attributes` dinámicos).
+    - Lógica *fallback* de `id` cuando viene vacío (usa `category` normalizada).
+  - `ModelPrice`: valor monetario con `mathPrecision`, `CurrencyEnum` (COP, USD, MXN, …) y
+    `decimalAmount` para conversión precisa.
+  - **Constantes:** `defaultModelItem`, `defaultModelPrice`.
+- **Taxonomía**
+  - `ModelCategory` (+ `ModelCategoryEnum`): modelo inmutable con *slug* canónico.
+    - API pública: `fromJson`, `toJson`, `copyWith`, `normalizeCategory(String)`.
+    - Igualdad/`hashCode` basados **solo** en `category` normalizada.
+- **Atributos tipados**
+  - `ModelAttribute<T>` (*alias* de `AttributeModel<T>`): atributos genéricos **compatibles con
+    Firestore** (tipos soportados).
+    - Helper `ModelAttribute.from<T>()` para construcción tipada con validación.
+- **Demo end-to-end (Store)**
+  - Ejemplo **single-file** listo para copiar (sin paquetes externos) mostrando:  
+    `UI → AppManager → Bloc → UseCase → Repository → Gateway → Service`  
+    usando `StoreModel`, `ModelItem`, `ModelPrice`, `ModelCategory`, `FinancialMovementModel` y
+    `LedgerModel`.
+    - Alinea precisión financiera con `ModelPrice(mathPrecision: 2)`.
+
+### Tests
+
+- `model_item_test.dart`: *round-trip* JSON, *fallback* de `id`, `copyWith`, igualdad/`hashCode`,
+  `toString`.
+- `model_price_test.dart`: matemática decimal, *fallback* de moneda, *round-trip*, `copyWith`.
+- `attribute_model_test.dart`: `from<T>()`, seguridad de tipos, *round-trip*, igualdad.
+- `model_category_test.dart`: matriz de normalización (espacios/puntuación/caso), *round-trip*,
+  igualdad basada en `category` normalizada, `copyWith`, `toJson` (trim de `description`).
+
+### Docs
+
+- DartDoc en **inglés** con ejemplo ejecutable para `ModelCategory`.
+- Guía del ejemplo **pet store** con precisión financiera alineada a `ModelPrice`.
+
+### Notes
+
+- Todos los modelos son **inmutables** y **serializables** (compatibles con Firestore).
+- **Sin cambios rompientes**: nuevas entidades y helpers son *opt-in*.
+- Si tu lógica dependía del signo de montos para ingreso/egreso, usa el `category`/tipo del item en
+  lugar de valores negativos.
+
 ## [1.31.1] - 2025-10-18
 
 ### Docs

--- a/doc/store-doc.md
+++ b/doc/store-doc.md
@@ -1,0 +1,791 @@
+# Pet Store (Store Flow) — Guía de implementación con `jocaagura_domain`
+
+Este documento explica, paso a paso, cómo montar una **tienda de mascotas** con `jocaagura_domain`
+siguiendo el **Suggested Flow**:
+
+> UI → AppManager → Bloc → UseCase → Repository → Gateway → Service
+
+> Consulta la guía de estructura completa:
+> [https://github.com/grupo-jocaagura/jocaagura_domain/raw/refs/heads/develop/README_STRUCTURE.md](https://github.com/grupo-jocaagura/jocaagura_domain/raw/refs/heads/develop/README_STRUCTURE.md)
+
+## Objetivo
+
+* Mostrar un flujo mínimo **reactivo** con `BlocGeneral` para:
+
+    * Cargar `StoreModel` (cabecera con NIT y teléfonos formateados).
+    * Listar `ModelItem` (con `ModelCategory`, `ModelPrice`, y atributos).
+    * Ver detalle y **agregar al carrito**.
+    * **Confirmar compra** (simulada) registrando un **ingreso** en `LedgerModel` mediante
+      `FinancialMovementModel` con precisión **2** (coherente con `ModelPrice`).
+
+## Requisitos
+
+* SDK: `sdk: ">=3.2.0 <4.0.0"`
+* Flutter: `">=1.17.0"`
+* Sin paquetes externos.
+* Importar el dominio:
+
+```dart
+import 'package:jocaagura_domain/jocaagura_domain.dart';
+```
+
+---
+
+## Ejemplo completo (copiar/pegar)
+
+> Pega este archivo como `lib/main.dart` en un proyecto Flutter que incluya `jocaagura_domain` en
+`pubspec.yaml`.
+> UI en **español**; **DartDoc en inglés** para APIs públicas del ejemplo.
+
+```dart
+// ignore_for_file: avoid_print
+import 'dart:math';
+import 'package:flutter/material.dart';
+import 'package:jocaagura_domain/jocaagura_domain.dart';
+
+void main() {
+  runApp(const PetStoreApp());
+}
+
+/// Top-level Jocaagura Pet Store demo app.
+/// UI in Spanish; public DartDoc in English as per Jocaagura docs.
+/// Suggested flow illustrated inside this single file:
+/// UI → AppManager → Bloc → UseCase → Repository → Gateway → Service
+class PetStoreApp extends StatefulWidget {
+  const PetStoreApp({super.key});
+
+  @override
+  State<PetStoreApp> createState() => _PetStoreAppState();
+}
+
+class _PetStoreAppState extends State<PetStoreApp> {
+  late final PetStoreAppManager _app;
+
+  @override
+  void initState() {
+    super.initState();
+    _app = PetStoreAppManager();
+    _app.bootstrap(); // seed store, catalog, empty ledger/cart
+  }
+
+  @override
+  void dispose() {
+    _app.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Jocaagura Pet Store',
+      theme: ThemeData(
+        colorSchemeSeed: Colors.teal,
+        useMaterial3: true,
+      ),
+      home: PetStoreHome(app: _app),
+    );
+  }
+}
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * UI (Pages & Widgets)
+ * ────────────────────────────────────────────────────────────────────────── */
+
+class PetStoreHome extends StatefulWidget {
+  const PetStoreHome({super.key, required this.app});
+  final PetStoreAppManager app;
+
+  @override
+  State<PetStoreHome> createState() => _PetStoreHomeState();
+}
+
+class _PetStoreHomeState extends State<PetStoreHome> {
+  String _query = '';
+
+  @override
+  Widget build(BuildContext context) {
+    final PetStoreAppManager app = widget.app;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Jocaagura Pet Store'),
+        actions: <Widget>[
+          // Botón carrito con indicador de cantidad (sin paquetes externos)
+          StreamBuilder<List<ModelItem>>(
+            stream: app.cartBloc.stream,
+            builder: (BuildContext _, AsyncSnapshot<List<ModelItem>> snap) {
+              final int count = snap.data?.length ?? 0;
+              return Stack(
+                alignment: Alignment.center,
+                children: <Widget>[
+                  IconButton(
+                    tooltip: 'Carrito',
+                    icon: const Icon(Icons.shopping_cart),
+                    onPressed: () {
+                      Navigator.of(context).push(
+                        MaterialPageRoute<void>(
+                          builder: (_) => CartPage(app: app),
+                        ),
+                      );
+                    },
+                  ),
+                  if (count > 0)
+                    Positioned(
+                      right: 10,
+                      top: 12,
+                      child: Container(
+                        padding: const EdgeInsets.all(4),
+                        decoration: const BoxDecoration(
+                          shape: BoxShape.circle,
+                          color: Colors.red,
+                        ),
+                        child: Text(
+                          '$count',
+                          style: const TextStyle(
+                            color: Colors.white,
+                            fontSize: 11,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                      ),
+                    ),
+                ],
+              );
+            },
+          ),
+        ],
+      ),
+      body: Column(
+        children: <Widget>[
+          // Header de tienda
+          StreamBuilder<StoreModel>(
+            stream: app.storeBloc.stream,
+            builder: (_, AsyncSnapshot<StoreModel> snap) {
+              final StoreModel store = snap.data ?? defaultStoreModel;
+              return StoreHeader(store: store);
+            },
+          ),
+          // Buscador
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            child: TextField(
+              decoration: const InputDecoration(
+                hintText: 'Buscar por nombre o categoría...',
+                prefixIcon: Icon(Icons.search),
+                border: OutlineInputBorder(),
+              ),
+              onChanged: (String v) => setState(() => _query = v.trim()),
+            ),
+          ),
+          // Lista de productos (filtrada por _query)
+          Expanded(
+            child: StreamBuilder<List<ModelItem>>(
+              stream: app.itemsBloc.stream,
+              builder: (_, AsyncSnapshot<List<ModelItem>> snap) {
+                final List<ModelItem> all = snap.data ?? <ModelItem>[];
+                final String q = _query.toLowerCase();
+                final List<ModelItem> filtered = q.isEmpty
+                    ? all
+                    : all.where((ModelItem e) {
+                        return e.name.toLowerCase().contains(q) ||
+                            e.type.category.toLowerCase().contains(q);
+                      }).toList();
+
+                if (filtered.isEmpty) {
+                  return const Center(
+                    child: Text('Sin resultados. Intenta con otro término.'),
+                  );
+                }
+
+                return ListView.separated(
+                  padding: const EdgeInsets.all(12),
+                  itemBuilder: (_, int i) {
+                    final ModelItem item = filtered[i];
+                    return ListTile(
+                      leading: CircleAvatar(
+                        child: Text(item.name.characters.first.toUpperCase()),
+                      ),
+                      title: Text(item.name),
+                      subtitle: Text(
+                        '${item.type.category} • ${item.price}',
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                      trailing: IconButton(
+                        tooltip: 'Agregar al carrito',
+                        icon: const Icon(Icons.add_shopping_cart),
+                        onPressed: () => app.addToCart(item),
+                      ),
+                      onTap: () {
+                        Navigator.of(context).push(
+                          MaterialPageRoute<void>(
+                            builder: (_) => ItemDetailPage(app: app, item: item),
+                          ),
+                        );
+                      },
+                    );
+                  },
+                  separatorBuilder: (_, __) => const Divider(height: 1),
+                  itemCount: filtered.length,
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class StoreHeader extends StatelessWidget {
+  const StoreHeader({super.key, required this.store});
+  final StoreModel store;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            // Nombre + Alias como subtítulo
+            Text(
+              store.name,
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+            Text(
+              store.alias,
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+            const SizedBox(height: 8),
+            // NIT con dígito de verificación
+            Text('NIT: ${store.nitNumber}'),
+            // Teléfonos formateados
+            Text('Tel 1: ${store.formatedPhoneNumber1}'),
+            Text('Tel 2: ${store.formatedPhoneNumber2}'),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class ItemDetailPage extends StatelessWidget {
+  const ItemDetailPage({super.key, required this.app, required this.item});
+  final PetStoreAppManager app;
+  final ModelItem item;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(item.name)),
+      floatingActionButton: FloatingActionButton.extended(
+        onPressed: () => app.addToCart(item),
+        label: const Text('Agregar al carrito'),
+        icon: const Icon(Icons.add),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: ListView(
+          children: <Widget>[
+            ListTile(
+              title: Text(item.name),
+              subtitle: Text(item.description),
+            ),
+            const SizedBox(height: 8),
+            Text('Categoría: ${item.type.category}'),
+            const SizedBox(height: 4),
+            Text('Precio: ${item.price}'),
+            const SizedBox(height: 12),
+            Text(
+              'Atributos',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: 4),
+            for (final ModelAttribute<dynamic> a in item.attributes)
+              Text('• ${a.name}: ${a.value}'),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class CartPage extends StatelessWidget {
+  const CartPage({super.key, required this.app});
+  final PetStoreAppManager app;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Carrito')),
+      body: StreamBuilder<List<ModelItem>>(
+        stream: app.cartBloc.stream,
+        builder: (_, AsyncSnapshot<List<ModelItem>> snap) {
+          final List<ModelItem> cart = snap.data ?? <ModelItem>[];
+          if (cart.isEmpty) {
+            return const Center(child: Text('Tu carrito está vacío.'));
+          }
+
+          final int minorTotal =
+              cart.fold<int>(0, (int acc, ModelItem e) => acc + e.price.amount);
+          final double decimalTotal = minorTotal /
+              pow(10, ModelPrice.defaultMathprecision).toDouble();
+
+          return Column(
+            children: <Widget>[
+              Expanded(
+                child: ListView.separated(
+                  padding: const EdgeInsets.all(12),
+                  itemBuilder: (_, int i) {
+                    final ModelItem item = cart[i];
+                    return ListTile(
+                      title: Text(item.name),
+                      subtitle: Text('${item.type.category} • ${item.price}'),
+                      trailing: IconButton(
+                        tooltip: 'Quitar',
+                        icon: const Icon(Icons.remove_circle_outline),
+                        onPressed: () => app.removeFromCart(item),
+                      ),
+                    );
+                  },
+                  separatorBuilder: (_, __) => const Divider(height: 1),
+                  itemCount: cart.length,
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
+                child: Column(
+                  children: <Widget>[
+                    Row(
+                      children: <Widget>[
+                        const Expanded(child: Text('Total')),
+                        Text('💰 ${decimalTotal.toStringAsFixed(ModelPrice.defaultMathprecision)} COP'),
+                      ],
+                    ),
+                    const SizedBox(height: 12),
+                    SizedBox(
+                      width: double.infinity,
+                      child: FilledButton.icon(
+                        icon: const Icon(Icons.check),
+                        label: const Text('Confirmar compra'),
+                        onPressed: () async {
+                          await app.confirmPurchase();
+                          if (context.mounted) {
+                            ScaffoldMessenger.of(context).showSnackBar(
+                              const SnackBar(
+                                content: Text('Compra registrada como ingreso.'),
+                              ),
+                            );
+                            Navigator.of(context).pop();
+                          }
+                        },
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * AppManager (ties Blocs + UseCases together)
+ * ────────────────────────────────────────────────────────────────────────── */
+
+/// Central coordinator for Pet Store demo.
+/// Holds the reactive blocs and orchestrates use cases.
+class PetStoreAppManager {
+  PetStoreAppManager()
+      : storeBloc = BlocGeneral<StoreModel>(defaultStoreModel),
+        itemsBloc = BlocGeneral<List<ModelItem>>(<ModelItem>[]),
+        cartBloc = BlocGeneral<List<ModelItem>>(<ModelItem>[]),
+        ledgerBloc = BlocGeneral<LedgerModel>(
+          defaultLedgerModel(), // starts empty-ish; we will append incomes on purchase
+        ) {
+    // Wiring use cases with repository pipeline
+    _service = FakePetStoreService();
+    _gateway = PetStoreGatewayImpl(_service);
+    _repository = PetStoreRepositoryImpl(_gateway);
+
+    loadStore = LoadStoreUseCase(_repository, storeBloc);
+    loadCatalog = LoadCatalogUseCase(_repository, itemsBloc);
+    addItemToCart = AddToCartUseCase(cartBloc);
+    removeItemFromCart = RemoveFromCartUseCase(cartBloc);
+    registerSale = RegisterSaleUseCase(ledgerBloc);
+  }
+
+  // Reactive blocs (domain's BlocGeneral)
+  final BlocGeneral<StoreModel> storeBloc;
+  final BlocGeneral<List<ModelItem>> itemsBloc;
+  final BlocGeneral<List<ModelItem>> cartBloc;
+  final BlocGeneral<LedgerModel> ledgerBloc;
+
+  // Pipeline: Service → Gateway → Repository
+  late final PetStoreService _service;
+  late final PetStoreGateway _gateway;
+  late final PetStoreRepository _repository;
+
+  // Use cases
+  late final LoadStoreUseCase loadStore;
+  late final LoadCatalogUseCase loadCatalog;
+  late final AddToCartUseCase addItemToCart;
+  late final RemoveFromCartUseCase removeItemFromCart;
+  late final RegisterSaleUseCase registerSale;
+
+  /// Bootstraps initial data and emits into blocs.
+  Future<void> bootstrap() async {
+    await loadStore();
+    await loadCatalog();
+  }
+
+  /// Convenience methods (UI-friendly)
+  void addToCart(ModelItem item) => addItemToCart(item);
+  void removeFromCart(ModelItem item) => removeItemFromCart(item);
+
+  /// Confirms purchase: creates a single income FinancialMovement and updates ledger.
+  Future<void> confirmPurchase() async {
+    final List<ModelItem> cart = cartBloc.value;
+    if (cart.isEmpty) return;
+
+    final int minorTotal =
+        cart.fold<int>(0, (int acc, ModelItem e) => acc + e.price.amount);
+
+    await registerSale(
+      concept: 'Venta',
+      decimalAmount: minorTotal /
+          pow(10, ModelPrice.defaultMathprecision).toDouble(),
+      when: DateTime.now(),
+    );
+
+    // Clear cart
+    cartBloc.value = <ModelItem>[];
+  }
+
+  void dispose() {
+    storeBloc.dispose();
+    itemsBloc.dispose();
+    cartBloc.dispose();
+    ledgerBloc.dispose();
+  }
+}
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * Use Cases
+ * ────────────────────────────────────────────────────────────────────────── */
+
+/// Loads the current store and publishes into [storeBloc].
+class LoadStoreUseCase {
+  LoadStoreUseCase(this._repo, this._storeBloc);
+  final PetStoreRepository _repo;
+  final BlocGeneral<StoreModel> _storeBloc;
+
+  /// Executes the use case.
+  Future<void> call() async {
+    final StoreModel store = await _repo.getStore();
+    _storeBloc.value = store;
+  }
+}
+
+/// Loads catalog items and publishes into [itemsBloc].
+class LoadCatalogUseCase {
+  LoadCatalogUseCase(this._repo, this._itemsBloc);
+  final PetStoreRepository _repo;
+  final BlocGeneral<List<ModelItem>> _itemsBloc;
+
+  Future<void> call() async {
+    final List<ModelItem> items = await _repo.getItems();
+    _itemsBloc.value = items;
+  }
+}
+
+/// Adds an item to the [cartBloc] keeping immutability semantics.
+class AddToCartUseCase {
+  AddToCartUseCase(this._cartBloc);
+  final BlocGeneral<List<ModelItem>> _cartBloc;
+
+  void call(ModelItem item) {
+    final List<ModelItem> next = <ModelItem>[..._cartBloc.value, item];
+    _cartBloc.value = List<ModelItem>.unmodifiable(next);
+  }
+}
+
+/// Removes the first occurrence of an item from the [cartBloc].
+class RemoveFromCartUseCase {
+  RemoveFromCartUseCase(this._cartBloc);
+  final BlocGeneral<List<ModelItem>> _cartBloc;
+
+  void call(ModelItem item) {
+    final List<ModelItem> copy = <ModelItem>[..._cartBloc.value];
+    final int idx = copy.indexWhere((ModelItem e) => e == item);
+    if (idx >= 0) {
+      copy.removeAt(idx);
+      _cartBloc.value = List<ModelItem>.unmodifiable(copy);
+    }
+  }
+}
+
+/// Registers a sale as an income movement into [ledgerBloc] with precision 2.
+///
+/// We align ledger precision with [ModelPrice.defaultMathprecision] (2)
+/// to keep a coherent, extensible representation with prices.
+class RegisterSaleUseCase {
+  RegisterSaleUseCase(this._ledgerBloc);
+  final BlocGeneral<LedgerModel> _ledgerBloc;
+
+  Future<void> call({
+    required String concept,
+    required double decimalAmount,
+    required DateTime when,
+  }) async {
+    final FinancialMovementModel movement =
+        FinancialMovementModel.fromDecimal(
+      id: 'sale-${when.microsecondsSinceEpoch}',
+      decimalAmount: decimalAmount,
+      date: when,
+      concept: concept,
+      category: 'Income',
+      createdAt: when,
+      precision: ModelPrice.defaultMathprecision, // 2
+    );
+
+    final LedgerModel current = _ledgerBloc.value;
+    final List<FinancialMovementModel> incomes =
+        <FinancialMovementModel>[...current.incomeLedger, movement];
+
+    _ledgerBloc.value = current.copyWith(
+      incomeLedger: List<FinancialMovementModel>.unmodifiable(incomes),
+    );
+  }
+}
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * Repository
+ * ────────────────────────────────────────────────────────────────────────── */
+
+/// Repository contract for the Pet Store demo.
+/// In a real app, this would live in the `Repository` layer.
+abstract class PetStoreRepository {
+  Future<StoreModel> getStore();
+  Future<List<ModelItem>> getItems();
+}
+
+/// Simple repository implementation delegating to [PetStoreGateway].
+class PetStoreRepositoryImpl implements PetStoreRepository {
+  PetStoreRepositoryImpl(this._gateway);
+  final PetStoreGateway _gateway;
+
+  @override
+  Future<StoreModel> getStore() => _gateway.fetchStore();
+
+  @override
+  Future<List<ModelItem>> getItems() => _gateway.fetchItems();
+}
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * Gateway
+ * ────────────────────────────────────────────────────────────────────────── */
+
+/// Gateway contract responsible for translating raw service JSON into domain models.
+abstract class PetStoreGateway {
+  Future<StoreModel> fetchStore();
+  Future<List<ModelItem>> fetchItems();
+}
+
+/// Minimal gateway implementation using a JSON-first fake service.
+class PetStoreGatewayImpl implements PetStoreGateway {
+  PetStoreGatewayImpl(this._service);
+  final PetStoreService _service;
+
+  @override
+  Future<StoreModel> fetchStore() async {
+    final Map<String, dynamic> json = await _service.getStoreJson();
+    return StoreModel.fromJson(json);
+  }
+
+  @override
+  Future<List<ModelItem>> fetchItems() async {
+    final List<Map<String, dynamic>> raw = await _service.getItemsJson();
+    return raw.map(ModelItem.fromJson).toList(growable: false);
+  }
+}
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * Service (Fake / In-memory)
+ * ────────────────────────────────────────────────────────────────────────── */
+
+/// Fake service that returns JSON shaped by the domain enums `.name`.
+/// This mimics a backend returning canonical JSON for the gateway.
+abstract class PetStoreService {
+  Future<Map<String, dynamic>> getStoreJson();
+  Future<List<Map<String, dynamic>>> getItemsJson();
+}
+
+/// In-memory fake service with seed data for "Jocaagura Pet Store".
+class FakePetStoreService implements PetStoreService {
+  @override
+  Future<Map<String, dynamic>> getStoreJson() async {
+    // Using defaultAddressModel from the domain.
+    final StoreModel store = StoreModel(
+      id: 'store_001',
+      nit: 987654321,
+      photoUrl: 'https://example.com/photo.jpg',
+      coverPhotoUrl: 'https://example.com/cover.jpg',
+      email: 'store@jocaagura.dev',
+      ownerEmail: 'owner@jocaagura.dev',
+      name: 'Jocaagura Pet Store',
+      alias: 'Pet Store',
+      address: defaultAddressModel,
+      phoneNumber1: 3001234567,
+      phoneNumber2: 6017654321,
+    );
+    return store.toJson();
+  }
+
+  @override
+  Future<List<Map<String, dynamic>>> getItemsJson() async {
+    // Seed: 6 productos típicos (algunos con id vacío para mostrar fallback de categoría)
+    final List<ModelItem> items = <ModelItem>[
+      _item(
+        id: '',
+        name: 'Comida Premium Gato 1Kg',
+        desc: 'Alimento balanceado para gato adulto.',
+        cat: 'cat-food',
+        priceMinor: 42000,
+        attrs: <ModelAttribute<dynamic>>[
+          AttributeModel.from<String>('Sabor', 'Pollo')!,
+          AttributeModel.from<int>('Stock', 25)!,
+        ],
+      ),
+      _item(
+        id: 'SKU-ARENA-CLASICA',
+        name: 'Arena Sanitaria 10Kg',
+        desc: 'Bentonita aglomerante.',
+        cat: 'cat-sand',
+        priceMinor: 38000,
+        attrs: <ModelAttribute<dynamic>>[
+          AttributeModel.from<String>('Fragancia', 'Neutra')!,
+          AttributeModel.from<int>('Stock', 15)!,
+        ],
+      ),
+      _item(
+        id: '',
+        name: 'Juguete Ratón',
+        desc: 'Juguete interactivo para gato.',
+        cat: 'toys',
+        priceMinor: 15000,
+        attrs: <ModelAttribute<dynamic>>[
+          AttributeModel.from<String>('Color', 'Azul')!,
+          AttributeModel.from<int>('Stock', 50)!,
+        ],
+      ),
+      _item(
+        id: 'SKU-CAMA-M',
+        name: 'Cama Mediana',
+        desc: 'Cama acolchada para mascota mediana.',
+        cat: 'beds',
+        priceMinor: 69000,
+        attrs: <ModelAttribute<dynamic>>[
+          AttributeModel.from<String>('Color', 'Gris')!,
+          AttributeModel.from<int>('Stock', 8)!,
+        ],
+      ),
+      _item(
+        id: '',
+        name: 'Correa Nylon',
+        desc: 'Correa resistente 1.5m.',
+        cat: 'accessories',
+        priceMinor: 22000,
+        attrs: <ModelAttribute<dynamic>>[
+          AttributeModel.from<String>('Color', 'Roja')!,
+          AttributeModel.from<int>('Stock', 30)!,
+        ],
+      ),
+      _item(
+        id: 'SKU-SNACK-01',
+        name: 'Snacks de Pollo 100g',
+        desc: 'Premios blandos.',
+        cat: 'snacks',
+        priceMinor: 12000,
+        attrs: <ModelAttribute<dynamic>>[
+          AttributeModel.from<String>('Tamaño', '100g')!,
+          AttributeModel.from<int>('Stock', 40)!,
+        ],
+      ),
+    ];
+
+    return items.map((ModelItem e) => e.toJson()).toList(growable: false);
+  }
+
+  static ModelItem _item({
+    required String id,
+    required String name,
+    required String desc,
+    required String cat,
+    required int priceMinor,
+    required List<ModelAttribute<dynamic>> attrs,
+  }) {
+    return ModelItem(
+      id: id,
+      name: name,
+      description: desc,
+      type: ModelCategory(category: cat, description: 'Pet store category'),
+      price: ModelPrice(
+        amount: priceMinor,
+        currency: CurrencyEnum.COP,
+        mathPrecision: ModelPrice.defaultMathprecision, // 2
+      ),
+      attributes: attrs,
+    );
+  }
+}
+```
+
+---
+
+## Cómo funciona (resumen)
+
+* **Service (Fake)**: `FakePetStoreService` devuelve **JSON** (no modelos) para tienda y catálogo.
+* **Gateway**: `PetStoreGatewayImpl` convierte ese JSON a **modelos** del dominio (`StoreModel`,
+  `ModelItem`, etc.).
+* **Repository**: `PetStoreRepositoryImpl` orquesta el acceso a datos y expone métodos de **alto
+  nivel** (e.g. `getItems()`).
+* **UseCases**:
+
+    * `LoadStoreUseCase` y `LoadCatalogUseCase` publican en `BlocGeneral` (reactivo).
+    * `AddToCartUseCase` y `RemoveFromCartUseCase` gestionan carrito **inmutable**.
+    * `RegisterSaleUseCase` registra una **venta** creando un `FinancialMovementModel` con precisión
+      **2** y lo agrega a `LedgerModel.incomeLedger`.
+* **UI**:
+
+    * `PetStoreHome` muestra la cabecera del store (con `nitNumber`, `formatedPhoneNumber1/2`) y
+      lista con búsqueda.
+    * `ItemDetailPage` renderiza atributos y permite **Agregar al carrito**.
+    * `CartPage` suma el total, lo muestra como `💰 12.50 COP` y al **Confirmar compra** registra el
+      ingreso en el Ledger.
+
+## Notas y contratos importantes
+
+* `ModelItem.id` vacío: al serializar con `toJson()` se usa *
+  *`ModelCategory.normalizeCategory(type.category)`** como identificador lógico. El ejemplo incluye
+  ítems con `id: ''` para evidenciarlo.
+* `ModelPrice` usa `defaultMathprecision = 2`. El ejemplo **alinea** el ledger a precisión **2** al
+  registrar la venta.
+* `BlocGeneral<T>`: se usa como contenedor **reactivo**. Las asignaciones se hacen **solo** vía
+  `bloc.value = ...`.
+
+## Troubleshooting breve
+
+* **Carrito no reacciona**: confirma que usas `bloc.value = List.unmodifiable(...)` al actualizar y
+  que la UI escucha `bloc.stream`.
+* **IDs vacíos**: es intencional para mostrar el fallback de categoría. Si persistes estos JSON,
+  verás los ids normalizados.
+* **Precision**: si ves totales con demasiados decimales, revisa que uses
+  `ModelPrice.defaultMathprecision` en todos los cálculos de compra.
+

--- a/example/lib/store_model_example.dart
+++ b/example/lib/store_model_example.dart
@@ -1,0 +1,728 @@
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+import 'package:jocaagura_domain/jocaagura_domain.dart';
+
+void main() {
+  runApp(const PetStoreApp());
+}
+
+/// Top-level Jocaagura Pet Store demo app.
+/// UI in Spanish; public DartDoc in English as per Jocaagura docs.
+/// Suggested flow illustrated inside this single file:
+/// UI → AppManager → Bloc → UseCase → Repository → Gateway → Service
+class PetStoreApp extends StatefulWidget {
+  const PetStoreApp({super.key});
+
+  @override
+  State<PetStoreApp> createState() => _PetStoreAppState();
+}
+
+class _PetStoreAppState extends State<PetStoreApp> {
+  late final PetStoreAppManager _app;
+
+  @override
+  void initState() {
+    super.initState();
+    _app = PetStoreAppManager();
+    _app.bootstrap(); // seed store, catalog, empty ledger/cart
+  }
+
+  @override
+  void dispose() {
+    _app.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Jocaagura Pet Store',
+      theme: ThemeData(
+        colorSchemeSeed: Colors.teal,
+        useMaterial3: true,
+      ),
+      home: PetStoreHome(app: _app),
+    );
+  }
+}
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * UI (Pages & Widgets)
+ * ────────────────────────────────────────────────────────────────────────── */
+
+class PetStoreHome extends StatefulWidget {
+  const PetStoreHome({required this.app, super.key});
+
+  final PetStoreAppManager app;
+
+  @override
+  State<PetStoreHome> createState() => _PetStoreHomeState();
+}
+
+class _PetStoreHomeState extends State<PetStoreHome> {
+  String _query = '';
+
+  @override
+  Widget build(BuildContext context) {
+    final PetStoreAppManager app = widget.app;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Jocaagura Pet Store'),
+        actions: <Widget>[
+          // Botón carrito con indicador de cantidad (sin paquetes externos)
+          StreamBuilder<List<ModelItem>>(
+            stream: app.cartBloc.stream,
+            builder: (BuildContext _, AsyncSnapshot<List<ModelItem>> snap) {
+              final int count = snap.data?.length ?? 0;
+              return Stack(
+                alignment: Alignment.center,
+                children: <Widget>[
+                  IconButton(
+                    tooltip: 'Carrito',
+                    icon: const Icon(Icons.shopping_cart),
+                    onPressed: () {
+                      Navigator.of(context).push(
+                        MaterialPageRoute<void>(
+                          builder: (_) => CartPage(app: app),
+                        ),
+                      );
+                    },
+                  ),
+                  if (count > 0)
+                    Positioned(
+                      right: 10,
+                      top: 12,
+                      child: Container(
+                        padding: const EdgeInsets.all(4),
+                        decoration: const BoxDecoration(
+                          shape: BoxShape.circle,
+                          color: Colors.red,
+                        ),
+                        child: Text(
+                          '$count',
+                          style: const TextStyle(
+                            color: Colors.white,
+                            fontSize: 11,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                      ),
+                    ),
+                ],
+              );
+            },
+          ),
+        ],
+      ),
+      body: Column(
+        children: <Widget>[
+          // Header de tienda
+          StreamBuilder<StoreModel>(
+            stream: app.storeBloc.stream,
+            builder: (_, AsyncSnapshot<StoreModel> snap) {
+              final StoreModel store = snap.data ?? defaultStoreModel;
+              return StoreHeader(store: store);
+            },
+          ),
+          // Buscador
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            child: TextField(
+              decoration: const InputDecoration(
+                hintText: 'Buscar por nombre o categoría...',
+                prefixIcon: Icon(Icons.search),
+                border: OutlineInputBorder(),
+              ),
+              onChanged: (String v) => setState(() => _query = v.trim()),
+            ),
+          ),
+          // Lista de productos (filtrada por _query)
+          Expanded(
+            child: StreamBuilder<List<ModelItem>>(
+              stream: app.itemsBloc.stream,
+              builder: (_, AsyncSnapshot<List<ModelItem>> snap) {
+                final List<ModelItem> all = snap.data ?? <ModelItem>[];
+                final String q = _query.toLowerCase();
+                final List<ModelItem> filtered = q.isEmpty
+                    ? all
+                    : all.where((ModelItem e) {
+                        return e.name.toLowerCase().contains(q) ||
+                            e.type.category.toLowerCase().contains(q);
+                      }).toList();
+
+                if (filtered.isEmpty) {
+                  return const Center(
+                    child: Text('Sin resultados. Intenta con otro término.'),
+                  );
+                }
+
+                return ListView.separated(
+                  padding: const EdgeInsets.all(12),
+                  itemBuilder: (_, int i) {
+                    final ModelItem item = filtered[i];
+                    return ListTile(
+                      leading: CircleAvatar(
+                        child: Text(item.name.characters.first.toUpperCase()),
+                      ),
+                      title: Text(item.name),
+                      subtitle: Text(
+                        '${item.type.category} • ${item.price}',
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                      trailing: IconButton(
+                        tooltip: 'Agregar al carrito',
+                        icon: const Icon(Icons.add_shopping_cart),
+                        onPressed: () => app.addToCart(item),
+                      ),
+                      onTap: () {
+                        Navigator.of(context).push(
+                          MaterialPageRoute<void>(
+                            builder: (_) =>
+                                ItemDetailPage(app: app, item: item),
+                          ),
+                        );
+                      },
+                    );
+                  },
+                  separatorBuilder: (_, __) => const Divider(height: 1),
+                  itemCount: filtered.length,
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class StoreHeader extends StatelessWidget {
+  const StoreHeader({required this.store, super.key});
+
+  final StoreModel store;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            // Nombre + Alias como subtítulo
+            Text(
+              store.name,
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+            Text(
+              store.alias,
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+            const SizedBox(height: 8),
+            // NIT con dígito de verificación
+            Text('NIT: ${store.nitNumber}'),
+            // Teléfonos formateados
+            Text('Tel 1: ${store.formatedPhoneNumber1}'),
+            Text('Tel 2: ${store.formatedPhoneNumber2}'),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class ItemDetailPage extends StatelessWidget {
+  const ItemDetailPage({required this.app, required this.item, super.key});
+
+  final PetStoreAppManager app;
+  final ModelItem item;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(item.name)),
+      floatingActionButton: FloatingActionButton.extended(
+        onPressed: () => app.addToCart(item),
+        label: const Text('Agregar al carrito'),
+        icon: const Icon(Icons.add),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: ListView(
+          children: <Widget>[
+            ListTile(
+              title: Text(item.name),
+              subtitle: Text(item.description),
+            ),
+            const SizedBox(height: 8),
+            Text('Categoría: ${item.type.category}'),
+            const SizedBox(height: 4),
+            Text('Precio: ${item.price}'),
+            const SizedBox(height: 12),
+            Text(
+              'Atributos',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: 4),
+            for (final ModelAttribute<dynamic> a in item.attributes)
+              Text('• ${a.name}: ${a.value}'),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class CartPage extends StatelessWidget {
+  const CartPage({required this.app, super.key});
+
+  final PetStoreAppManager app;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Carrito')),
+      body: StreamBuilder<List<ModelItem>>(
+        stream: app.cartBloc.stream,
+        builder: (_, AsyncSnapshot<List<ModelItem>> snap) {
+          final List<ModelItem> cart = snap.data ?? <ModelItem>[];
+          if (cart.isEmpty) {
+            return const Center(child: Text('Tu carrito está vacío.'));
+          }
+
+          final int minorTotal =
+              cart.fold<int>(0, (int acc, ModelItem e) => acc + e.price.amount);
+          final double decimalTotal =
+              minorTotal / pow(10, ModelPrice.defaultMathprecision).toDouble();
+
+          return Column(
+            children: <Widget>[
+              Expanded(
+                child: ListView.separated(
+                  padding: const EdgeInsets.all(12),
+                  itemBuilder: (_, int i) {
+                    final ModelItem item = cart[i];
+                    return ListTile(
+                      title: Text(item.name),
+                      subtitle: Text('${item.type.category} • ${item.price}'),
+                      trailing: IconButton(
+                        tooltip: 'Quitar',
+                        icon: const Icon(Icons.remove_circle_outline),
+                        onPressed: () => app.removeFromCart(item),
+                      ),
+                    );
+                  },
+                  separatorBuilder: (_, __) => const Divider(height: 1),
+                  itemCount: cart.length,
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
+                child: Column(
+                  children: <Widget>[
+                    Row(
+                      children: <Widget>[
+                        const Expanded(child: Text('Total')),
+                        Text('💰 ${decimalTotal.toStringAsFixed(
+                          ModelPrice.defaultMathprecision,
+                        )} COP'),
+                      ],
+                    ),
+                    const SizedBox(height: 12),
+                    SizedBox(
+                      width: double.infinity,
+                      child: FilledButton.icon(
+                        icon: const Icon(Icons.check),
+                        label: const Text('Confirmar compra'),
+                        onPressed: () async {
+                          await app.confirmPurchase();
+                          if (context.mounted) {
+                            ScaffoldMessenger.of(context).showSnackBar(
+                              const SnackBar(
+                                content:
+                                    Text('Compra registrada como ingreso.'),
+                              ),
+                            );
+                            Navigator.of(context).pop();
+                          }
+                        },
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * AppManager (ties Blocs + UseCases together)
+ * ────────────────────────────────────────────────────────────────────────── */
+
+/// Central coordinator for Pet Store demo.
+/// Holds the reactive blocs and orchestrates use cases.
+class PetStoreAppManager {
+  PetStoreAppManager()
+      : storeBloc = BlocGeneral<StoreModel>(defaultStoreModel),
+        itemsBloc = BlocGeneral<List<ModelItem>>(<ModelItem>[]),
+        cartBloc = BlocGeneral<List<ModelItem>>(<ModelItem>[]),
+        ledgerBloc = BlocGeneral<LedgerModel>(
+          defaultLedgerModel(), // starts empty-ish; we will append incomes on purchase
+        ) {
+    // Wiring use cases with repository pipeline
+    _service = FakePetStoreService();
+    _gateway = PetStoreGatewayImpl(_service);
+    _repository = PetStoreRepositoryImpl(_gateway);
+
+    loadStore = LoadStoreUseCase(_repository, storeBloc);
+    loadCatalog = LoadCatalogUseCase(_repository, itemsBloc);
+    addItemToCart = AddToCartUseCase(cartBloc);
+    removeItemFromCart = RemoveFromCartUseCase(cartBloc);
+    registerSale = RegisterSaleUseCase(ledgerBloc);
+  }
+
+  // Reactive blocs (domain's BlocGeneral)
+  final BlocGeneral<StoreModel> storeBloc;
+  final BlocGeneral<List<ModelItem>> itemsBloc;
+  final BlocGeneral<List<ModelItem>> cartBloc;
+  final BlocGeneral<LedgerModel> ledgerBloc;
+
+  // Pipeline: Service → Gateway → Repository
+  late final PetStoreService _service;
+  late final PetStoreGateway _gateway;
+  late final PetStoreRepository _repository;
+
+  // Use cases
+  late final LoadStoreUseCase loadStore;
+  late final LoadCatalogUseCase loadCatalog;
+  late final AddToCartUseCase addItemToCart;
+  late final RemoveFromCartUseCase removeItemFromCart;
+  late final RegisterSaleUseCase registerSale;
+
+  /// Bootstraps initial data and emits into blocs.
+  Future<void> bootstrap() async {
+    await loadStore();
+    await loadCatalog();
+  }
+
+  /// Convenience methods (UI-friendly)
+  void addToCart(ModelItem item) => addItemToCart(item);
+
+  void removeFromCart(ModelItem item) => removeItemFromCart(item);
+
+  /// Confirms purchase: creates a single income FinancialMovement and updates ledger.
+  Future<void> confirmPurchase() async {
+    final List<ModelItem> cart = cartBloc.value;
+    if (cart.isEmpty) {
+      return;
+    }
+
+    final int minorTotal =
+        cart.fold<int>(0, (int acc, ModelItem e) => acc + e.price.amount);
+
+    await registerSale(
+      concept: 'Venta',
+      decimalAmount:
+          minorTotal / pow(10, ModelPrice.defaultMathprecision).toDouble(),
+      when: DateTime.now(),
+    );
+
+    // Clear cart
+    cartBloc.value = <ModelItem>[];
+  }
+
+  void dispose() {
+    storeBloc.dispose();
+    itemsBloc.dispose();
+    cartBloc.dispose();
+    ledgerBloc.dispose();
+  }
+}
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * Use Cases
+ * ────────────────────────────────────────────────────────────────────────── */
+
+/// Loads the current store and publishes into [storeBloc].
+class LoadStoreUseCase {
+  LoadStoreUseCase(this._repo, this._storeBloc);
+
+  final PetStoreRepository _repo;
+  final BlocGeneral<StoreModel> _storeBloc;
+
+  /// Executes the use case.
+  Future<void> call() async {
+    final StoreModel store = await _repo.getStore();
+    _storeBloc.value = store;
+  }
+}
+
+/// Loads catalog items and publishes into [itemsBloc].
+class LoadCatalogUseCase {
+  LoadCatalogUseCase(this._repo, this._itemsBloc);
+
+  final PetStoreRepository _repo;
+  final BlocGeneral<List<ModelItem>> _itemsBloc;
+
+  Future<void> call() async {
+    final List<ModelItem> items = await _repo.getItems();
+    _itemsBloc.value = items;
+  }
+}
+
+/// Adds an item to the [cartBloc] keeping immutability semantics.
+class AddToCartUseCase {
+  AddToCartUseCase(this._cartBloc);
+
+  final BlocGeneral<List<ModelItem>> _cartBloc;
+
+  void call(ModelItem item) {
+    final List<ModelItem> next = <ModelItem>[..._cartBloc.value, item];
+    _cartBloc.value = List<ModelItem>.unmodifiable(next);
+  }
+}
+
+/// Removes the first occurrence of an item from the [cartBloc].
+class RemoveFromCartUseCase {
+  RemoveFromCartUseCase(this._cartBloc);
+
+  final BlocGeneral<List<ModelItem>> _cartBloc;
+
+  void call(ModelItem item) {
+    final List<ModelItem> copy = <ModelItem>[..._cartBloc.value];
+    final int idx = copy.indexWhere((ModelItem e) => e == item);
+    if (idx >= 0) {
+      copy.removeAt(idx);
+      _cartBloc.value = List<ModelItem>.unmodifiable(copy);
+    }
+  }
+}
+
+/// Registers a sale as an income movement into [ledgerBloc] with precision 2.
+///
+/// We align ledger precision with [ModelPrice.defaultMathprecision] (2)
+/// to keep a coherent, extensible representation with prices.
+class RegisterSaleUseCase {
+  RegisterSaleUseCase(this._ledgerBloc);
+
+  final BlocGeneral<LedgerModel> _ledgerBloc;
+
+  Future<void> call({
+    required String concept,
+    required double decimalAmount,
+    required DateTime when,
+  }) async {
+    final FinancialMovementModel movement = FinancialMovementModel.fromDecimal(
+      id: 'sale-${when.microsecondsSinceEpoch}',
+      decimalAmount: decimalAmount,
+      date: when,
+      concept: concept,
+      category: 'Income',
+      createdAt: when,
+      precision: ModelPrice.defaultMathprecision, // 2
+    );
+
+    final LedgerModel current = _ledgerBloc.value;
+    final List<FinancialMovementModel> incomes = <FinancialMovementModel>[
+      ...current.incomeLedger,
+      movement,
+    ];
+
+    _ledgerBloc.value = current.copyWith(
+      incomeLedger: List<FinancialMovementModel>.unmodifiable(incomes),
+    );
+  }
+}
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * Repository
+ * ────────────────────────────────────────────────────────────────────────── */
+
+/// Repository contract for the Pet Store demo.
+/// In a real app, this would live in the `Repository` layer.
+abstract class PetStoreRepository {
+  Future<StoreModel> getStore();
+
+  Future<List<ModelItem>> getItems();
+}
+
+/// Simple repository implementation delegating to [PetStoreGateway].
+class PetStoreRepositoryImpl implements PetStoreRepository {
+  PetStoreRepositoryImpl(this._gateway);
+
+  final PetStoreGateway _gateway;
+
+  @override
+  Future<StoreModel> getStore() => _gateway.fetchStore();
+
+  @override
+  Future<List<ModelItem>> getItems() => _gateway.fetchItems();
+}
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * Gateway
+ * ────────────────────────────────────────────────────────────────────────── */
+
+/// Gateway contract responsible for translating raw service JSON into domain models.
+abstract class PetStoreGateway {
+  Future<StoreModel> fetchStore();
+
+  Future<List<ModelItem>> fetchItems();
+}
+
+/// Minimal gateway implementation using a JSON-first fake service.
+class PetStoreGatewayImpl implements PetStoreGateway {
+  PetStoreGatewayImpl(this._service);
+
+  final PetStoreService _service;
+
+  @override
+  Future<StoreModel> fetchStore() async {
+    final Map<String, dynamic> json = await _service.getStoreJson();
+    return StoreModel.fromJson(json);
+  }
+
+  @override
+  Future<List<ModelItem>> fetchItems() async {
+    final List<Map<String, dynamic>> raw = await _service.getItemsJson();
+    return raw.map(ModelItem.fromJson).toList(growable: false);
+  }
+}
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * Service (Fake / In-memory)
+ * ────────────────────────────────────────────────────────────────────────── */
+
+/// Fake service that returns JSON shaped by the domain enums `.name`.
+/// This mimics a backend returning canonical JSON for the gateway.
+abstract class PetStoreService {
+  Future<Map<String, dynamic>> getStoreJson();
+
+  Future<List<Map<String, dynamic>>> getItemsJson();
+}
+
+/// In-memory fake service with seed data for "Jocaagura Pet Store".
+class FakePetStoreService implements PetStoreService {
+  @override
+  Future<Map<String, dynamic>> getStoreJson() async {
+    // Using defaultAddressModel from the domain.
+    const StoreModel store = StoreModel(
+      id: 'store_001',
+      nit: 987654321,
+      photoUrl: 'https://example.com/photo.jpg',
+      coverPhotoUrl: 'https://example.com/cover.jpg',
+      email: 'store@jocaagura.dev',
+      ownerEmail: 'owner@jocaagura.dev',
+      name: 'Jocaagura Pet Store',
+      alias: 'Pet Store',
+      address: defaultAddressModel,
+      phoneNumber1: 3001234567,
+      phoneNumber2: 6017654321,
+    );
+    return store.toJson();
+  }
+
+  @override
+  Future<List<Map<String, dynamic>>> getItemsJson() async {
+    // Seed: 6 productos típicos (algunos con id vacío para mostrar fallback de categoría)
+    final List<ModelItem> items = <ModelItem>[
+      _item(
+        id: '',
+        name: 'Comida Premium Gato 1Kg',
+        desc: 'Alimento balanceado para gato adulto.',
+        cat: 'cat-food',
+        priceMinor: 42000,
+        attrs: <ModelAttribute<dynamic>>[
+          AttributeModel.from<String>('Sabor', 'Pollo')!,
+          AttributeModel.from<int>('Stock', 25)!,
+        ],
+      ),
+      _item(
+        id: 'SKU-ARENA-CLASICA',
+        name: 'Arena Sanitaria 10Kg',
+        desc: 'Bentonita aglomerante.',
+        cat: 'cat-sand',
+        priceMinor: 38000,
+        attrs: <ModelAttribute<dynamic>>[
+          AttributeModel.from<String>('Fragancia', 'Neutra')!,
+          AttributeModel.from<int>('Stock', 15)!,
+        ],
+      ),
+      _item(
+        id: '',
+        name: 'Juguete Ratón',
+        desc: 'Juguete interactivo para gato.',
+        cat: 'toys',
+        priceMinor: 15000,
+        attrs: <ModelAttribute<dynamic>>[
+          AttributeModel.from<String>('Color', 'Azul')!,
+          AttributeModel.from<int>('Stock', 50)!,
+        ],
+      ),
+      _item(
+        id: 'SKU-CAMA-M',
+        name: 'Cama Mediana',
+        desc: 'Cama acolchada para mascota mediana.',
+        cat: 'beds',
+        priceMinor: 69000,
+        attrs: <ModelAttribute<dynamic>>[
+          AttributeModel.from<String>('Color', 'Gris')!,
+          AttributeModel.from<int>('Stock', 8)!,
+        ],
+      ),
+      _item(
+        id: '',
+        name: 'Correa Nylon',
+        desc: 'Correa resistente 1.5m.',
+        cat: 'accessories',
+        priceMinor: 22000,
+        attrs: <ModelAttribute<dynamic>>[
+          AttributeModel.from<String>('Color', 'Roja')!,
+          AttributeModel.from<int>('Stock', 30)!,
+        ],
+      ),
+      _item(
+        id: 'SKU-SNACK-01',
+        name: 'Snacks de Pollo 100g',
+        desc: 'Premios blandos.',
+        cat: 'snacks',
+        priceMinor: 12000,
+        attrs: <ModelAttribute<dynamic>>[
+          AttributeModel.from<String>('Tamaño', '100g')!,
+          AttributeModel.from<int>('Stock', 40)!,
+        ],
+      ),
+    ];
+
+    return items.map((ModelItem e) => e.toJson()).toList(growable: false);
+  }
+
+  static ModelItem _item({
+    required String id,
+    required String name,
+    required String desc,
+    required String cat,
+    required int priceMinor,
+    required List<ModelAttribute<dynamic>> attrs,
+  }) {
+    return ModelItem(
+      id: id,
+      name: name,
+      description: desc,
+      type: ModelCategory(category: cat, description: 'Pet store category'),
+      price: ModelPrice(
+        amount: priceMinor,
+        currency: CurrencyEnum.COP,
+      ),
+      attributes: attrs,
+    );
+  }
+}

--- a/lib/domain/attribute_model.dart
+++ b/lib/domain/attribute_model.dart
@@ -1,55 +1,60 @@
 part of '../jocaagura_domain.dart';
 
+/// Alias for backwards compatibility.
+typedef ModelAttribute<T> = AttributeModel<T>;
+
 enum AttributeEnum {
   name,
   value,
 }
 
-/// Represents a generic attribute with a name and a value, where the value is of a generic type [T].
+/// Represents an immutable name–value attribute where [value] is of type [T].
 ///
-/// The type [T] must maintain compatibility with Firestore data types:
-/// - **Compatible Firestore Data Types**: Ensure that all values are types Firestore can handle,
-/// including `String`, `Number` (integers and floats), `Boolean`, `Map`, `Array`, `Null`,
-/// `Timestamp`, `GeoPoint`, and binary blobs.
-/// Using unsupported types may cause errors or unexpected behavior.
+/// This model is storage-agnostic; values should be *serializable* in your
+/// chosen persistence layer. Collections are allowed but their elements are
+/// not recursively validated by this class.
 ///
-/// Example of using [AttributeModel] in a practical application:
+/// ### Contracts
+/// - **Equality:** Two attributes are equal iff both `name` and `value` are equal.
+///   Equality does **not** depend on `hashCode`.
+/// - **Immutability:** Fields are `final`. Use [copyWith] to derive a new instance.
+/// - **Serialization:** [toJson] returns `{ "value": <T>, "name": <String> }`.
 ///
+/// ### Minimal runnable example
 /// ```dart
 /// void main() {
-///   var attribute = AttributeModel<String>(
-///     name: 'Color',
-///     value: 'Blue',
+///   final AttributeModel<String> color = AttributeModel<String>(
+///     name: 'color',
+///     value: 'blue',
 ///   );
 ///
-///   print('Attribute Name: ${attribute.name}');
-///   print('Attribute Value: ${attribute.value}');
+///   final AttributeModel<String> copy = color.copyWith(value: 'red');
+///   print(color.toJson()); // {value: blue, name: color}
+///   print(copy);           // prints JSON string
 ///
-///   var numberAttribute = AttributeModel<int>(
-///     name: 'Age',
-///     value: 30,
-///   );
-///
-///   print('Attribute Name: ${numberAttribute.name}');
-///   print('Attribute Value: ${numberAttribute.value}');
+///   // Equality contract
+///   assert(color != copy);
 /// }
 /// ```
 ///
-/// This class is essential for managing flexible attribute data in systems where the type of value varies.
+/// ### Usage notes
+/// - If you need strict compatibility with a backend (e.g., Firestore), validate
+///   types at your mapper/boundary layer. This class only does a shallow check
+///   via [AttributeModel.isDomainCompatible].
 class AttributeModel<T> extends Model {
-  /// Constructs a new [AttributeModel] with the given [name] and [value].
+  /// Creates an [AttributeModel] with a [name] and a [value] of type [T].
   const AttributeModel({
     required this.value,
     required this.name,
   });
 
-  /// The value of the attribute, with type [T].
+  /// The attribute value.
   final T value;
 
-  /// The name of the attribute.
+  /// The attribute name.
   final String name;
 
-  /// Creates a copy of this [AttributeModel] with optional new values.
+  /// Returns a new [AttributeModel] replacing the provided fields.
   @override
   AttributeModel<T> copyWith({
     String? name,
@@ -60,7 +65,8 @@ class AttributeModel<T> extends Model {
         name: name ?? this.name,
       );
 
-  /// Serializes this [AttributeModel] into a JSON map.
+  /// Serializes this attribute to a JSON map:
+  /// `{ "value": <T>, "name": <String> }`.
   @override
   Map<String, dynamic> toJson() {
     return <String, dynamic>{
@@ -69,54 +75,86 @@ class AttributeModel<T> extends Model {
     };
   }
 
-  /// Determines if two [AttributeModel] instances are equal.
+  /// Equality is based on `name` and `value` only.
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-      other is AttributeModel &&
+      other is AttributeModel<T> &&
           runtimeType == other.runtimeType &&
           value == other.value &&
-          name == other.name &&
-          hashCode == other.hashCode;
+          name == other.name;
 
-  /// Returns the hash code for this [AttributeModel].
+  /// Hash code consistent with equality.
   @override
-  int get hashCode => '$value$name'.hashCode;
+  int get hashCode => Object.hash(name, value);
 
-  /// Returns a string representation of this [AttributeModel].
-  ///
-  /// This method serializes the object to a JSON string.
+  /// JSON string representation.
   @override
   String toString() {
     return jsonEncode(toJson());
   }
+
+  /// Factory helper that returns a typed [AttributeModel] if [value] is
+  /// considered serializable for the domain; otherwise returns `null`.
+  static AttributeModel<T>? from<T>(String name, T value) {
+    if (isDomanCompatible(value)) {
+      return AttributeModel<T>(name: name, value: value);
+    }
+    return null;
+  }
+
+  /// Shallow check for domain-serializable types.
+  ///
+  /// Supports: `String`, `num`, `bool`, `DateTime`, `Map`, `List`, and `null`.
+  /// Does **not** validate nested elements.
+  static bool isDomanCompatible(dynamic value) {
+    return value == null ||
+        value is String ||
+        value is num ||
+        value is bool ||
+        value is DateTime ||
+        value is Map ||
+        value is List;
+  }
 }
 
-/// Deserializes a JSON map into an [AttributeModel] of type [T].
+/// Deserializes an [AttributeModel] of type [T] using a converter for the value.
 ///
-/// The [fromJsonT] parameter is a function that converts the raw JSON value
-/// into the desired type [T].
+/// The converter [fromJsonT] transforms the raw JSON field into [T].
 ///
-/// Example of deserializing an [AttributeModel]:
-///
+/// ### Minimal runnable example
 /// ```dart
-/// var json = {
-///   'name': 'Weight',
-///   'value': 70,
-/// };
+/// void main() {
+///   final Map<String, dynamic> json = <String, dynamic>{
+///     'name': 'weight',
+///     'value': 70,
+///   };
 ///
-/// var attribute = attributeModelfromJson<int>(json, (value) => value as int);
-/// print('Attribute Name: ${attribute.name}');
-/// print('Attribute Value: ${attribute.value}');
+///   final AttributeModel<int> attr = attributeModelFromJson<int>(
+///     json,
+///     (dynamic v) => v as int,
+///   );
+///
+///   print(attr.name);  // weight
+///   print(attr.value); // 70
+/// }
 /// ```
+@Deprecated('Use static from<T> instead.')
 AttributeModel<T> attributeModelfromJson<T>(
   Map<String, dynamic> json,
   T Function(dynamic) fromJsonT,
+) =>
+    attributeModelFromJson<T>(json, fromJsonT);
+
+// New idiomatic name
+AttributeModel<T> attributeModelFromJson<T>(
+  Map<String, dynamic> json,
+  T Function(dynamic) fromJsonT,
 ) {
-  dynamic value = json['value'];
-  value = fromJsonT(value);
+  final dynamic raw = json[AttributeEnum.value.name];
+  final T value = fromJsonT(raw);
   return AttributeModel<T>(
     name: json[AttributeEnum.name.name]?.toString() ?? '',
-    value: value as T,
+    value: value,
   );
 }

--- a/lib/domain/financial/financial_movement.dart
+++ b/lib/domain/financial/financial_movement.dart
@@ -1,4 +1,7 @@
-part of '../../jocaagura_domain.dart';
+part of 'package:jocaagura_domain/jocaagura_domain.dart';
+
+/// Alias for domain compatibility.
+typedef ModelFinancialMovement = FinancialMovementModel;
 
 /// Enumerates the JSON field names for [FinancialMovementModel].
 enum FinancialMovementEnum {

--- a/lib/domain/financial/ledger_model.dart
+++ b/lib/domain/financial/ledger_model.dart
@@ -1,4 +1,7 @@
-part of '../../jocaagura_domain.dart';
+part of 'package:jocaagura_domain/jocaagura_domain.dart';
+
+/// Alias for domain compatibility.
+typedef ModelLedger = LedgerModel;
 
 enum LedgerEnum { nameOfLedger, incomeLedger, expenseLedger }
 

--- a/lib/domain/store/model_category.dart
+++ b/lib/domain/store/model_category.dart
@@ -1,0 +1,106 @@
+part of 'package:jocaagura_domain/jocaagura_domain.dart';
+
+/// Enumerates the property keys used in [ModelCategory].
+///
+/// These keys ensure consistency across serialization and deserialization.
+enum ModelCategoryEnum {
+  /// Unique logical identifier for the category.
+  category,
+
+  /// Description or explanation of the category's purpose.
+  description,
+}
+
+/// Default instance of [ModelCategory] used for testing or fallback purposes.
+///
+/// Provides a simple placeholder category example.
+const ModelCategory defaultModelCategory = ModelCategory(
+  category: 'default-category',
+  description: 'Default category for generic tagging or testing purposes.',
+);
+
+/// A minimal model representing a reusable category or tag.
+///
+/// This model is often used to classify items (e.g., products, services).
+/// The [category] acts as a unique logical ID and is normalized to
+/// `middle_snake_case` on `toJson`.
+///
+/// ### Example:
+/// ```dart
+/// final ModelCategory tag = ModelCategory(
+///   category: 'Pet Store',
+///   description: 'Items related to pets and animals',
+/// );
+///
+/// print(tag.toJson());
+/// // { category: pet_store, description: Items related to pets and animals }
+/// ```
+class ModelCategory extends Model {
+  /// Creates a new immutable [ModelCategory] instance.
+  const ModelCategory({
+    required this.category,
+    required this.description,
+  });
+
+  /// Creates a [ModelCategory] from a JSON [Map].
+  factory ModelCategory.fromJson(Map<String, dynamic> json) {
+    return ModelCategory(
+      category:
+          Utils.getStringFromDynamic(json[ModelCategoryEnum.category.name]),
+      description:
+          Utils.getStringFromDynamic(json[ModelCategoryEnum.description.name]),
+    );
+  }
+
+  /// Unique logical identifier of the category.
+  final String category;
+
+  /// Description or tooltip for the category.
+  final String description;
+
+  /// Creates a copy of this [ModelCategory] with optional new values.
+  @override
+  ModelCategory copyWith({
+    String? category,
+    String? description,
+  }) {
+    return ModelCategory(
+      category: category ?? this.category,
+      description: description ?? this.description,
+    );
+  }
+
+  /// Converts this [ModelCategory] into a JSON [Map], normalizing the category key.
+  @override
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      ModelCategoryEnum.category.name: normalizeCategory(category),
+      ModelCategoryEnum.description.name: description.trim(),
+    };
+  }
+
+  static String normalizeCategory(String value) {
+    return value
+        .trim()
+        .replaceAll(RegExp(r'[^a-zA-Z0-9\- ]'), '')
+        .replaceAll(RegExp(r'\s+'), '-')
+        .replaceAll(RegExp(r'-{2,}'), '-')
+        .toLowerCase();
+  }
+
+  /// Overrides the hashCode using only the `category` field.
+  @override
+  int get hashCode => normalizeCategory(category).hashCode;
+
+  /// Equality is based solely on the normalized category.
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ModelCategory &&
+          runtimeType == other.runtimeType &&
+          normalizeCategory(category) == normalizeCategory(other.category);
+
+  /// Pretty print for debugging.
+  @override
+  String toString() => '📦 Category($category): $description';
+}

--- a/lib/domain/store/model_item.dart
+++ b/lib/domain/store/model_item.dart
@@ -1,0 +1,189 @@
+part of 'package:jocaagura_domain/jocaagura_domain.dart';
+
+/// Enumerates the JSON field names used by [ModelItem].
+///
+/// Contracts:
+/// - Keys are serialized by `name`, making the enum order irrelevant.
+/// - Keep names stable to avoid breaking persisted data.
+///
+/// Example:
+/// ```dart
+/// void main() {
+///   final Map<String, dynamic> json = <String, dynamic>{
+///     ModelItemEnum.id.name: 'SKU-123',
+///     ModelItemEnum.name.name: 'Surgical Mask',
+///   };
+///   print(json.keys); // (id, name)
+/// }
+/// ```
+enum ModelItemEnum {
+  id,
+  name,
+  description,
+  type,
+  price,
+  attributes,
+}
+
+/// Represents an immutable item (product/service) with metadata, price and attributes.
+///
+/// The `attributes` list is exposed as **read-only**; attempting to mutate it
+/// at runtime will throw. Use [copyWith] to derive new instances.
+///
+/// ### Contracts
+/// - **Immutability:** lists are wrapped with `List.unmodifiable`.
+/// - **Identifier fallback:** when `id` is empty, `toJson()` uses
+///   `ModelCategory.normalizeCategory(type.category)` as a logical identifier.
+/// - **Serialization:** `{ id, name, description, type, price, attributes }`.
+///   `name` and `description` are serialized **trimmed**.
+///
+/// ### Minimal runnable example
+/// ```dart
+/// void main() {
+///   final ModelItem item = ModelItem(
+///     id: '',
+///     name: '  Surgical Mask  ',
+///     description: '  Disposable protective face mask  ',
+///     type: ModelCategory(category: 'health-supplies', description: 'Health-related items'),
+///     price: ModelPrice(amount: 2500, currency: CurrencyEnum.COP),
+///     attributes: <ModelAttribute<dynamic>>[
+///       AttributeModel.from<String>('Color', 'Blue')!,
+///       AttributeModel.from<int>('Stock', 50)!,
+///     ],
+///   );
+///
+///   print(item.attributes.length); // 2
+///   print(item.toJson()['id']);    // normalized category when original id is empty
+///   // item.attributes.add(...);   // will throw (unmodifiable)
+/// }
+/// ```
+///
+/// ### Notes
+/// - `toString()` displays minor units and currency code from [ModelPrice]; for a
+///   human-friendly decimal string consider using a currency helper/formatter.
+class ModelItem extends Model {
+  ModelItem({
+    required this.id,
+    required this.name,
+    required this.description,
+    required this.type,
+    required this.price,
+    List<ModelAttribute<dynamic>> attributes =
+        const <ModelAttribute<dynamic>>[],
+  }) : attributes = List<ModelAttribute<dynamic>>.unmodifiable(attributes);
+
+  /// Builds a [ModelItem] from JSON.
+  factory ModelItem.fromJson(Map<String, dynamic> json) {
+    return ModelItem(
+      id: Utils.getStringFromDynamic(json[ModelItemEnum.id.name]),
+      name: Utils.getStringFromDynamic(json[ModelItemEnum.name.name]),
+      description:
+          Utils.getStringFromDynamic(json[ModelItemEnum.description.name]),
+      type: ModelCategory.fromJson(
+        Utils.mapFromDynamic(json[ModelItemEnum.type.name]),
+      ),
+      price: ModelPrice.fromJson(
+        Utils.mapFromDynamic(json[ModelItemEnum.price.name]),
+      ),
+      attributes: Utils.listFromDynamic(json[ModelItemEnum.attributes.name])
+          .map(
+            (Map<String, dynamic> e) =>
+                attributeModelfromJson<dynamic>(e, (dynamic v) => v),
+          )
+          .toList(),
+    );
+  }
+
+  /// Unique identifier for the item. May be empty on new instances.
+  final String id;
+
+  /// Human-readable name.
+  final String name;
+
+  /// Long description or details.
+  final String description;
+
+  /// Logical classification/category.
+  final ModelCategory type;
+
+  /// Price configuration.
+  final ModelPrice price;
+
+  /// Read-only attribute list (e.g., size, color, stock).
+  final List<ModelAttribute<dynamic>> attributes;
+
+  /// Serializes this item to JSON using trimmed `name`/`description`.
+  @override
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      ModelItemEnum.id.name:
+          id.isEmpty ? ModelCategory.normalizeCategory(type.category) : id,
+      ModelItemEnum.name.name: name.trim(),
+      ModelItemEnum.description.name: description.trim(),
+      ModelItemEnum.type.name: type.toJson(),
+      ModelItemEnum.price.name: price.toJson(),
+      ModelItemEnum.attributes.name:
+          attributes.map((ModelAttribute<dynamic> e) => e.toJson()).toList(),
+    };
+  }
+
+  /// Derives a new [ModelItem] overriding selected fields.
+  ///
+  /// The resulting instance preserves the read-only `attributes` contract.
+  @override
+  ModelItem copyWith({
+    String? id,
+    String? name,
+    String? description,
+    ModelCategory? type,
+    ModelPrice? price,
+    List<ModelAttribute<dynamic>>? attributes,
+  }) {
+    return ModelItem(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      description: description ?? this.description,
+      type: type ?? this.type,
+      price: price ?? this.price,
+      attributes: attributes ?? this.attributes,
+    );
+  }
+
+  /// Structural equality including attributes (order-sensitive).
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ModelItem &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          name == other.name &&
+          description == other.description &&
+          type == other.type &&
+          price == other.price &&
+          Utils.listEquals(attributes, other.attributes);
+
+  /// Hash code consistent with equality.
+  @override
+  int get hashCode => Object.hash(
+        id,
+        name,
+        description,
+        type,
+        price,
+        Utils.listHash(attributes),
+      );
+
+  /// Human-readable summary.
+  @override
+  String toString() =>
+      '📦 Item($id): $name — ${type.category}, ${price.amount} @ ${price.currency}';
+}
+
+/// Default instance of [ModelItem] useful for test/fallback.
+final ModelItem defaultModelItem = ModelItem(
+  id: '',
+  name: 'Default Item',
+  description: 'This is a placeholder item',
+  type: defaultModelCategory,
+  price: defaultModelPrice,
+);

--- a/lib/domain/store/model_price.dart
+++ b/lib/domain/store/model_price.dart
@@ -1,0 +1,236 @@
+part of 'package:jocaagura_domain/jocaagura_domain.dart';
+
+/// Enumerates the JSON field names used by [ModelPrice].
+///
+/// Contracts:
+/// - These keys are **stable** and serialized by `name`.
+/// - Reordering the enum does not affect JSON when using `name`-based encoding.
+///
+/// Example:
+/// ```dart
+/// void main() {
+///   final Map<String, dynamic> json = <String, dynamic>{
+///     ModelPriceEnum.amount.name: 1250,
+///     ModelPriceEnum.mathPrecision.name: 2,
+///     ModelPriceEnum.currency.name: CurrencyEnum.COP.name,
+///   };
+///   // { "amount": 1250, "mathPrecision": 2, "currency": "COP" }
+/// }
+/// ```
+enum ModelPriceEnum {
+  amount,
+  mathPrecision,
+  currency,
+}
+
+/// Supported currency codes for prices and transactions.
+///
+/// Codes are serialized/deserialized by **enum name** (e.g., `"COP"`, `"USD"`).
+/// This list focuses on Hispanoamérica and includes a few common globals/crypto
+/// codes used in apps.
+///
+/// ### Notes
+/// - Adding new codes is **non-breaking** as long as JSON uses `currency.name`.
+/// - Avoid relying on `CurrencyEnum.values[index]` in persistence; prefer names.
+/// - Venezuela uses `VES` (replaces older `VEF`).
+/// - Panamá usa `PAB` y también `USD`.
+/// - El Salvador opera en `USD` (el código `SVC` existe pero está en desuso).
+///
+/// ### Example
+/// ```dart
+/// void main() {
+///   final CurrencyEnum c = CurrencyEnum.MXN;
+///   print(c.name); // "MXN"
+/// }
+/// ```
+enum CurrencyEnum {
+  COP, // Colombia
+  USD, // United States dollar (también de curso en SV y PA)
+  MXN, // México
+  PEN, // Perú (Sol)
+  CLP, // Chile (Peso)
+  ARS, // Argentina (Peso)
+  BRL, // Brasil (Real)
+  EUR, // Euro
+  BTC, // Bitcoin (crypto)
+  USDT, // Tether (stablecoin)
+  BOB, // Bolivia (Boliviano)
+  CRC, // Costa Rica (Colón)
+  DOP, // República Dominicana (Peso)
+  GTQ, // Guatemala (Quetzal)
+  HNL, // Honduras (Lempira)
+  NIO, // Nicaragua (Córdoba)
+  PAB, // Panamá (Balboa; convive con USD)
+  PYG, // Paraguay (Guaraní)
+  UYU, // Uruguay (Peso Uruguayo)
+  VES, // Venezuela (Bolívar Soberano)
+}
+
+/// Represents an immutable monetary amount stored in minor units, with its
+/// decimal precision and currency.
+///
+/// Values are stored in `amount` (minor units). The decimal value is derived as:
+/// `decimalAmount = amount / pow(10, mathPrecision)`.
+///
+/// ### Contracts
+/// - `amount` **must be non-negative**.
+/// - `mathPrecision` **must be non-negative** (defaults to [defaultMathprecision]).
+/// - `currency` is required and encoded/decoded by its enum name (e.g. `"COP"`).
+/// - JSON shape: `{ "amount": int, "mathPrecision": int, "currency": String }`.
+///
+/// ### Minimal runnable example
+/// ```dart
+/// void main() {
+///   // 12.50 COP represented as 1250 minor units with precision 2
+///   final ModelPrice price = ModelPrice(
+///     amount: 1250,
+///     currency: CurrencyEnum.COP,
+///     mathPrecision: ModelPrice.defaultMathprecision, // 2
+///   );
+///
+///   print(price.decimalAmount); // 12.5
+///   print(price.toJson());      // {amount: 1250, mathPrecision: 2, currency: COP}
+///   print(price);               // 💰 12.50 COP
+///
+///   // copyWith normalizes negatives: amount -> abs, precision -> non-negative
+///   final ModelPrice updated = price.copyWith(amount: -1999, mathPrecision: -1);
+///   print(updated.amount);        // 1999
+///   print(updated.mathPrecision); // 2 (fallback to default)
+/// }
+/// ```
+///
+/// ### Notes
+/// - `decimalAmount` uses floating-point division; for display, prefer
+///   `toString()` or `toStringAsFixed(mathPrecision)` to avoid rounding artifacts.
+class ModelPrice extends Model {
+  /// Creates a new immutable [ModelPrice].
+  ///
+  /// Throws (debug mode):
+  /// - [AssertionError] if `amount < 0` or `mathPrecision < 0`.
+  const ModelPrice({
+    required this.amount,
+    required this.currency,
+    this.mathPrecision = defaultMathprecision,
+  })  : assert(amount >= 0),
+        assert(mathPrecision >= 0);
+
+  /// Builds a [ModelPrice] from a JSON map.
+  ///
+  /// Behavior:
+  /// - `amount` is parsed and coerced to absolute value.
+  /// - `mathPrecision` is parsed as integer (no clamping here; constructor asserts non-negative).
+  /// - Unknown `currency` names default to [CurrencyEnum.COP].
+  ///
+  /// Example:
+  /// ```dart
+  /// void main() {
+  ///   final ModelPrice p = ModelPrice.fromJson({
+  ///     'amount': -999, // abs() => 999
+  ///     'mathPrecision': 2,
+  ///     'currency': 'USD',
+  ///   });
+  ///   print(p); // 💰 9.99 USD
+  /// }
+  /// ```
+  factory ModelPrice.fromJson(Map<String, dynamic> json) {
+    return ModelPrice(
+      amount:
+          Utils.getIntegerFromDynamic(json[ModelPriceEnum.amount.name]).abs(),
+      mathPrecision:
+          Utils.getIntegerFromDynamic(json[ModelPriceEnum.mathPrecision.name]),
+      currency: CurrencyEnum.values.firstWhere(
+        (CurrencyEnum e) =>
+            e.name ==
+            Utils.getStringFromDynamic(json[ModelPriceEnum.currency.name]),
+        orElse: () => CurrencyEnum.COP,
+      ),
+    );
+  }
+
+  /// Default decimal precision used when not provided.
+  static const int defaultMathprecision = 2;
+
+  /// Amount in minor units (scaled by [mathPrecision]); must be non-negative.
+  final int amount;
+
+  /// Number of decimal places used to scale [amount].
+  ///
+  /// Example: `2` ⇒ 100 minor units = 1.00.
+  final int mathPrecision;
+
+  /// ISO-like currency code from [CurrencyEnum] (e.g., `COP`, `USD`, `EUR`).
+  final CurrencyEnum currency;
+
+  /// Decimal representation computed as `amount / pow(10, mathPrecision)`.
+  double get decimalAmount => amount / pow(10, mathPrecision);
+
+  /// Serializes this price to JSON:
+  /// `{ "amount": int, "mathPrecision": int, "currency": String }`.
+  @override
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        ModelPriceEnum.amount.name: amount,
+        ModelPriceEnum.mathPrecision.name: mathPrecision,
+        ModelPriceEnum.currency.name: currency.name,
+      };
+
+  /// Returns a new [ModelPrice] overriding the provided fields.
+  ///
+  /// Normalization rules:
+  /// - Negative `amount` is coerced to `abs(amount)`.
+  /// - Negative `mathPrecision` falls back to [defaultMathprecision].
+  ///
+  /// Example:
+  /// ```dart
+  /// void main() {
+  ///   const ModelPrice p = ModelPrice(amount: 100, currency: CurrencyEnum.EUR);
+  ///   final ModelPrice q = p.copyWith(amount: -250, mathPrecision: -3);
+  ///   print(q.amount);        // 250
+  ///   print(q.mathPrecision); // 2 (default)
+  /// }
+  /// ```
+  @override
+  ModelPrice copyWith({
+    int? amount,
+    int? mathPrecision,
+    CurrencyEnum? currency,
+  }) =>
+      ModelPrice(
+        amount: (amount ?? this.amount).abs(),
+        mathPrecision: (mathPrecision ?? this.mathPrecision) < 0
+            ? defaultMathprecision
+            : (mathPrecision ?? this.mathPrecision),
+        currency: currency ?? this.currency,
+      );
+
+  /// Structural equality on `amount`, `mathPrecision`, and `currency`.
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ModelPrice &&
+          runtimeType == other.runtimeType &&
+          amount == other.amount &&
+          mathPrecision == other.mathPrecision &&
+          currency == other.currency;
+
+  /// Hash code consistent with equality.
+  @override
+  int get hashCode => Object.hash(amount, mathPrecision, currency);
+
+  /// Human-readable representation (e.g., `💰 12.50 COP`).
+  @override
+  String toString() =>
+      '💰 ${decimalAmount.toStringAsFixed(mathPrecision)} ${currency.name}';
+}
+
+/// Default price model used for testing or fallbacks.
+///
+/// Example:
+/// ```dart
+/// void main() {
+///   print(defaultModelPrice); // 💰 0.00 COP
+/// }
+/// ```
+const ModelPrice defaultModelPrice = ModelPrice(
+  amount: 0,
+  currency: CurrencyEnum.COP,
+);

--- a/lib/jocaagura_domain.dart
+++ b/lib/jocaagura_domain.dart
@@ -97,6 +97,11 @@ part 'domain/states/onboarding_state.dart';
 part 'domain/states/onboarding_step.dart';
 part 'domain/states/session_state.dart';
 part 'domain/states/ws_db_state.dart';
+part 'domain/store/model_category.dart';
+
+part 'domain/store/model_item.dart';
+
+part 'domain/store/model_price.dart';
 part 'domain/store_model.dart';
 part 'domain/ui/model_main_menu_model.dart';
 part 'domain/ui/screen_size_config.dart';

--- a/test/domain/attribute_model_test.dart
+++ b/test/domain/attribute_model_test.dart
@@ -104,4 +104,59 @@ void main() {
       expect(model.toString(), expectedString);
     });
   });
+  group('🔖 AttributeModel', () {
+    test('from<T> creates valid attribute when type is compatible', () {
+      final ModelAttribute<String>? attrStr =
+          ModelAttribute.from('Color', 'Red');
+      final ModelAttribute<int>? attrInt = ModelAttribute.from('Stock', 50);
+
+      expect(attrStr, isNotNull);
+      expect(attrStr!.value, equals('Red'));
+      expect(attrInt, isNotNull);
+      expect(attrInt!.value, equals(50));
+    });
+
+    test('from<T> returns null for unsupported types', () {
+      final ModelAttribute<Uri>? invalid = ModelAttribute.from('Link', Uri());
+      expect(invalid, isNull);
+    });
+
+    test('toJson ↔ fromJson roundtrip', () {
+      const ModelAttribute<String> original = ModelAttribute<String>(
+        name: 'Size',
+        value: 'Large',
+      );
+      final Map<String, dynamic> json = original.toJson();
+      final AttributeModel<String> parsed = attributeModelfromJson<String>(
+        json,
+        (dynamic v) => v as String,
+      );
+      expect(parsed, equals(original));
+    });
+
+    test('copyWith updates only provided fields', () {
+      const AttributeModel<String> attr =
+          ModelAttribute<String>(name: 'Material', value: 'Cotton');
+      final AttributeModel<String> copy = attr.copyWith(value: 'Linen');
+      expect(copy.name, equals('Material'));
+      expect(copy.value, equals('Linen'));
+    });
+
+    test('toString returns a valid JSON string', () {
+      const AttributeModel<int> attr =
+          ModelAttribute<int>(name: 'Stock', value: 25);
+      final String str = attr.toString();
+      expect(str, contains('"Stock"'));
+      expect(str, contains('25'));
+    });
+
+    test('Equality and hashCode are consistent', () {
+      const AttributeModel<String> a =
+          ModelAttribute<String>(name: 'Color', value: 'Blue');
+      const AttributeModel<String> b =
+          ModelAttribute<String>(name: 'Color', value: 'Blue');
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+    });
+  });
 }

--- a/test/domain/store/model_category_test.dart
+++ b/test/domain/store/model_category_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jocaagura_domain/jocaagura_domain.dart';
+
+void main() {
+  group('🧪 ModelCategory', () {
+    const ModelCategory original = ModelCategory(
+      category: 'Pet Store',
+      description: 'Items related to pets and animals',
+    );
+
+    test('1️⃣ Roundtrip (toJson <-> fromJson)', () {
+      final Map<String, dynamic> json = original.toJson();
+      final ModelCategory fromJson = ModelCategory.fromJson(json);
+
+      expect(fromJson, equals(original));
+      expect(fromJson.toJson(), equals(json));
+    });
+
+    test('2️⃣ Category normalization on toJson', () {
+      final Map<String, dynamic> json = original.toJson();
+      expect(json['category'], equals('pet-store'));
+    });
+
+    test('3️⃣ copyWith preserves immutability and updates values', () {
+      final ModelCategory modified =
+          original.copyWith(description: 'Updated desc');
+
+      expect(modified.category, equals(original.category));
+      expect(modified.description, equals('Updated desc'));
+      expect(modified == original, isFalse);
+    });
+
+    test('4️⃣ Equality and hashCode based only on category', () {
+      const ModelCategory sameCategoryDifferentDesc = ModelCategory(
+        category: 'Pet Store',
+        description: 'Completely different text',
+      );
+
+      expect(sameCategoryDifferentDesc, equals(original));
+      expect(sameCategoryDifferentDesc.hashCode, equals(original.hashCode));
+    });
+
+    test('5️⃣ toString includes emoji and description', () {
+      final String result = original.toString();
+      expect(result, contains('📦 Category(Pet Store):'));
+    });
+
+    test('6️⃣ Default instance serializes correctly', () {
+      expect(
+        defaultModelCategory.toJson()['category'],
+        equals('default-category'),
+      );
+    });
+  });
+}

--- a/test/domain/store/model_item_test.dart
+++ b/test/domain/store/model_item_test.dart
@@ -1,0 +1,197 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jocaagura_domain/jocaagura_domain.dart';
+
+void main() {
+  group('📦 ModelItem', () {
+    final ModelItem original = ModelItem(
+      id: '',
+      name: 'Ice Cream',
+      description: 'Delicious vanilla ice cream',
+      type: const ModelCategory(
+        category: 'Food Products',
+        description: 'Consumables',
+      ),
+      price: const ModelPrice(
+        amount: 1899,
+        currency: CurrencyEnum.COP,
+      ),
+      attributes: const <AttributeModel<dynamic>>[
+        AttributeModel<String>(name: 'Size', value: 'Small'),
+        AttributeModel<int>(name: 'Stock', value: 20),
+      ],
+    );
+
+    test('Roundtrip toJson ↔ fromJson preserves data', () {
+      final Map<String, dynamic> json = original.toJson();
+      final ModelItem parsed = ModelItem.fromJson(json);
+
+      expect(parsed.toJson(), equals(json));
+      expect(parsed, isNot(same(defaultModelItem)));
+    });
+
+    test('Fallback ID from type.category normalization', () {
+      final String fallbackId = original.toJson()['id'].toString();
+      expect(fallbackId, equals('food-products'));
+    });
+
+    test('copyWith updates selected fields', () {
+      final ModelItem copy = original.copyWith(name: 'Updated');
+      expect(copy.name, equals('Updated'));
+      expect(copy.id, equals(original.id));
+    });
+
+    test('Equality and hashCode are consistent', () {
+      final ModelItem other = original.copyWith();
+      expect(other, equals(original));
+      expect(other.hashCode, equals(original.hashCode));
+    });
+
+    test('toString contains relevant info', () {
+      final String output = original.toString();
+      expect(output.contains('Ice Cream'), isTrue);
+      expect(output.contains('Food'), isTrue);
+      expect(output.contains('Products'), isTrue);
+    });
+  });
+
+  group('💰 ModelPrice', () {
+    const ModelPrice price = ModelPrice(
+      amount: 1050,
+      currency: CurrencyEnum.USD,
+    );
+
+    test('decimalAmount is computed correctly', () {
+      expect(price.decimalAmount, equals(10.5));
+    });
+
+    test('CurrencyEnum roundtrip works', () {
+      final Map<String, dynamic> json = price.toJson();
+      final ModelPrice parsed = ModelPrice.fromJson(json);
+      expect(parsed.currency, equals(CurrencyEnum.USD));
+      expect(parsed, equals(price));
+    });
+
+    test('copyWith retains and replaces values correctly', () {
+      final ModelPrice updated = price.copyWith(amount: 2000);
+      expect(updated.amount, equals(2000));
+      expect(updated.currency, equals(CurrencyEnum.USD));
+    });
+  });
+
+  group('ModelItem', () {
+    test('Given attributes list When constructed Then becomes unmodifiable',
+        () {
+      final List<ModelAttribute<dynamic>> attrs = <ModelAttribute<dynamic>>[
+        const AttributeModel<String>(name: 'Color', value: 'Blue'),
+      ];
+      final ModelItem item = ModelItem(
+        id: '',
+        name: 'Mask',
+        description: 'Medical mask',
+        type: const ModelCategory(category: 'health', description: 'x'),
+        price: const ModelPrice(amount: 2500, currency: CurrencyEnum.COP),
+        attributes: attrs,
+      );
+
+      // mutate original list -> item.attributes must not change
+      attrs.add(const AttributeModel<int>(name: 'Stock', value: 10));
+      expect(item.attributes.length, 1);
+
+      // list must be truly unmodifiable
+      expect(
+        () => item.attributes
+            .add(const AttributeModel<String>(name: 'S', value: 'x')),
+        throwsUnsupportedError,
+      );
+    });
+
+    test('Given empty id When toJson Then id falls back to normalized category',
+        () {
+      final ModelItem item = ModelItem(
+        id: '',
+        name: '  Mask  ',
+        description: '  Medical  ',
+        type:
+            const ModelCategory(category: 'health-supplies', description: 'x'),
+        price: const ModelPrice(amount: 1000, currency: CurrencyEnum.COP),
+      );
+      final Map<String, dynamic> json = item.toJson();
+      expect(json['id'], ModelCategory.normalizeCategory('health-supplies'));
+      expect(json['name'], 'Mask');
+      expect(json['description'], 'Medical');
+    });
+
+    test('Given json When fromJson Then roundtrip preserves fields', () {
+      final Map<String, dynamic> json = <String, dynamic>{
+        'id': 'SKU1',
+        'name': 'Gloves',
+        'description': 'Latex',
+        'type':
+            const ModelCategory(category: 'health', description: 'x').toJson(),
+        'price':
+            const ModelPrice(amount: 1999, currency: CurrencyEnum.USD).toJson(),
+        'attributes': <Map<String, dynamic>>[
+          const AttributeModel<String>(name: 'Size', value: 'M').toJson(),
+          const AttributeModel<int>(name: 'Stock', value: 50).toJson(),
+        ],
+      };
+      final ModelItem item = ModelItem.fromJson(json);
+      expect(item.id, 'SKU1');
+      expect(item.name, 'Gloves');
+      expect(item.price.currency, CurrencyEnum.USD);
+      expect(item.attributes.length, 2);
+    });
+
+    test(
+        'Given copyWith When change fields Then new instance with same immutability',
+        () {
+      final ModelItem base = ModelItem(
+        id: 'A',
+        name: 'Item',
+        description: 'Desc',
+        type: const ModelCategory(category: 'cat', description: 'x'),
+        price: const ModelPrice(amount: 100, currency: CurrencyEnum.EUR),
+      );
+
+      final ModelItem changed = base.copyWith(
+        id: 'B',
+        attributes: <ModelAttribute<dynamic>>[
+          const AttributeModel<bool>(name: 'Fragile', value: true),
+        ],
+      );
+
+      expect(changed.id, 'B');
+      expect(
+        () => changed.attributes
+            .add(const AttributeModel<int>(name: 'X', value: 1)),
+        throwsUnsupportedError,
+      );
+    });
+
+    test('Given equals/hash When same fields Then equality true and hash equal',
+        () {
+      final ModelItem a = ModelItem(
+        id: 'A',
+        name: 'N',
+        description: 'D',
+        type: const ModelCategory(category: 'cat', description: 'x'),
+        price: const ModelPrice(amount: 1, currency: CurrencyEnum.CLP),
+        attributes: const <ModelAttribute<dynamic>>[
+          AttributeModel<int>(name: 'Stock', value: 1),
+        ],
+      );
+      final ModelItem b = ModelItem(
+        id: 'A',
+        name: 'N',
+        description: 'D',
+        type: const ModelCategory(category: 'cat', description: 'x'),
+        price: const ModelPrice(amount: 1, currency: CurrencyEnum.CLP),
+        attributes: const <ModelAttribute<dynamic>>[
+          AttributeModel<int>(name: 'Stock', value: 1),
+        ],
+      );
+      expect(a == b, isTrue);
+      expect(a.hashCode, equals(b.hashCode));
+    });
+  });
+}

--- a/test/domain/store/model_price_test.dart
+++ b/test/domain/store/model_price_test.dart
@@ -1,0 +1,130 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jocaagura_domain/jocaagura_domain.dart';
+
+void main() {
+  group('💰 ModelPrice', () {
+    const ModelPrice original = ModelPrice(
+      amount: 12345,
+      currency: CurrencyEnum.USD,
+    );
+
+    test('toJson ↔ fromJson roundtrip', () {
+      final Map<String, dynamic> json = original.toJson();
+      final ModelPrice parsed = ModelPrice.fromJson(json);
+
+      expect(parsed, equals(original));
+      expect(parsed.toJson(), equals(json));
+    });
+
+    test('decimalAmount reflects scaled amount', () {
+      expect(original.decimalAmount, equals(123.45));
+    });
+
+    test('copyWith overrides only specified fields', () {
+      final ModelPrice updated = original.copyWith(amount: 999);
+
+      expect(updated.amount, equals(999));
+      expect(updated.mathPrecision, equals(original.mathPrecision));
+      expect(updated.currency, equals(original.currency));
+    });
+
+    test('CurrencyEnum defaults to COP if not found', () {
+      final ModelPrice fallback = ModelPrice.fromJson(const <String, dynamic>{
+        'amount': 2000,
+        'mathPrecision': 2,
+        'currency': 'NON_EXISTENT',
+      });
+
+      expect(fallback.currency, equals(CurrencyEnum.COP));
+    });
+
+    test('toString includes decimal and currency', () {
+      expect(original.toString(), contains('USD'));
+      expect(original.toString(), contains('123.45'));
+    });
+  });
+
+  group('ModelPrice', () {
+    test('Given valid inputs When construct Then decimalAmount correct', () {
+      const ModelPrice p = ModelPrice(
+        amount: 1250,
+        currency: CurrencyEnum.COP,
+      );
+      expect(p.decimalAmount, closeTo(12.5, 0.0000001));
+      expect(p.toString(), '💰 12.50 COP');
+    });
+
+    test('Given negative amount When construct Then assert (debug mode)', () {
+      expect(
+        () => ModelPrice(
+          amount: -1,
+          currency: CurrencyEnum.USD,
+        ),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+
+    test('Given negative precision When construct Then assert (debug mode)',
+        () {
+      expect(
+        () => ModelPrice(
+          amount: 1,
+          mathPrecision: -1,
+          currency: CurrencyEnum.USD,
+        ),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+
+    test('Given fromJson with unknown currency When parse Then defaults to COP',
+        () {
+      final ModelPrice p = ModelPrice.fromJson(const <String, Object?>{
+        'amount': -999, // will be abs() => 999
+        'mathPrecision': 2,
+        'currency': '???',
+      });
+      expect(p.amount, 999);
+      expect(p.currency, CurrencyEnum.COP);
+      expect(p.decimalAmount, closeTo(9.99, 0.0000001));
+    });
+
+    test('Given copyWith When amount negative Then coerced to abs', () {
+      const ModelPrice base = ModelPrice(
+        amount: 100,
+        currency: CurrencyEnum.EUR,
+      );
+      final ModelPrice changed = base.copyWith(amount: -250);
+      expect(changed.amount, 250);
+      expect(changed.mathPrecision, 2);
+      expect(changed.currency, CurrencyEnum.EUR);
+    });
+
+    test(
+        'Given copyWith When precision negative Then normalized to non-negative',
+        () {
+      const ModelPrice base = ModelPrice(
+        amount: 100,
+        currency: CurrencyEnum.USD,
+      );
+      final ModelPrice changed = base.copyWith(mathPrecision: -3);
+      expect(changed.mathPrecision, ModelPrice.defaultMathprecision);
+      expect(changed.decimalAmount, 1.00);
+    });
+
+    test('Given two equal instances When compare Then == true and hash equal',
+        () {
+      const ModelPrice a = ModelPrice(amount: 1, currency: CurrencyEnum.CLP);
+      const ModelPrice b = ModelPrice(amount: 1, currency: CurrencyEnum.CLP);
+      expect(a == b, isTrue);
+      expect(a.hashCode, equals(b.hashCode));
+    });
+
+    test('Given toJson When serialize Then matches expected keys', () {
+      const ModelPrice p = ModelPrice(amount: 123, currency: CurrencyEnum.MXN);
+      final Map<String, dynamic> json = p.toJson();
+      expect(json['amount'], 123);
+      expect(json['mathPrecision'], 2);
+      expect(json['currency'], 'MXN');
+    });
+  });
+}

--- a/test/domain/store_model_test.dart
+++ b/test/domain/store_model_test.dart
@@ -67,4 +67,81 @@ void main() {
       expect(defaultStoreModel.formatedPhoneNumber2, '000 078 9012');
     });
   });
+  group('StoreModel', () {
+    test('Given address When toJson Then address is a JSON map (not string)',
+        () {
+      const StoreModel s = StoreModel(
+        id: 'id',
+        nit: 12345,
+        photoUrl: 'https://x/p.jpg',
+        coverPhotoUrl: 'https://x/c.jpg',
+        email: 'e@x.com',
+        ownerEmail: 'o@x.com',
+        name: 'N',
+        alias: 'A',
+        address: defaultAddressModel,
+        phoneNumber1: 111,
+        phoneNumber2: 222,
+      );
+      final dynamic addr = s.toJson()['address'];
+      expect(addr, isA<Map<String, dynamic>>());
+    });
+
+    test('Given two equal stores When compare Then == true and hash equal', () {
+      const StoreModel a = StoreModel(
+        id: '1',
+        nit: 10,
+        photoUrl: 'p',
+        coverPhotoUrl: 'c',
+        email: 'a@x.com',
+        ownerEmail: 'o@x.com',
+        name: 'N',
+        alias: 'A',
+        address: defaultAddressModel,
+        phoneNumber1: 1,
+        phoneNumber2: 2,
+      );
+      const StoreModel b = StoreModel(
+        id: '1',
+        nit: 10,
+        photoUrl: 'p',
+        coverPhotoUrl: 'c',
+        email: 'a@x.com',
+        ownerEmail: 'o@x.com',
+        name: 'N',
+        alias: 'A',
+        address: defaultAddressModel,
+        phoneNumber1: 1,
+        phoneNumber2: 2,
+      );
+      expect(a == b, isTrue);
+      expect(a.hashCode, equals(b.hashCode));
+    });
+
+    test('Given nit When getVerificationNITNumber Then returns dv in [0,1..9]',
+        () {
+      final int dv = StoreModel.getVerificationNITNumber(900373106);
+      expect(dv, inInclusiveRange(0, 9));
+    });
+
+    test('Given fromJson Then roundtrip preserves shape and address map', () {
+      final Map<String, dynamic> json = <String, dynamic>{
+        'id': 'xyz',
+        'nit': 123,
+        'photoUrl': 'https://x/p.jpg',
+        'coverPhotoUrl': 'https://x/c.jpg',
+        'email': 'e@x.com',
+        'ownerEmail': 'o@x.com',
+        'name': 'Name',
+        'alias': 'Alias',
+        'address': defaultAddressModel.toJson(),
+        'phoneNumber1': 555,
+        'phoneNumber2': 666,
+      };
+      final StoreModel s = StoreModel.fromJson(json);
+      final Map<String, dynamic> out = s.toJson();
+      expect(out['address'], isA<Map<String, dynamic>>());
+      expect(out['id'], 'xyz');
+    });
+  });
 }


### PR DESCRIPTION
#107 complete
* feat(domain/model): add `ModelCategory` (+ enum) with normalized slug and full test suite

- Introduces `ModelCategory` as a minimal, immutable, reusable taxonomy/tag model.
- Public API:
  - `enum ModelCategoryEnum { category, description }` for stable JSON keys.
  - `ModelCategory.fromJson(Map)`, `toJson()`, `copyWith()`.
  - `normalizeCategory(String)` to create a canonical slug:
    * trim → strip non-alphanumerics → collapse spaces to `-` → lowercase.
  - Equality and `hashCode` are based **only** on the normalized `category`.
  - Friendly `toString()` for debugging.
- Serialization:
  - `toJson()` outputs the normalized `category` and a trimmed `description`.
  - Parsing uses `Utils.getStringFromDynamic` for resilience.

Docs:
- DartDoc in English with a runnable usage example.

Tests (no external packages):
- Round-trip JSON: `fromJson(toJson(model))` preserves semantics.
- Normalization matrix (spaces, punctuation, case) → same canonical slug.
- Equality/hashCode depend solely on normalized `category` (description changes don’t affect equality).
- `copyWith()` creates a new instance and preserves immutability.
- `toJson()` trims `description`.

No breaking changes to existing API.

* feat(domain): add ModelItem and ModelPrice with roundtrip support and tests

- Introduce `ModelItem`, a minimal and extensible entity for products or services:
  - Includes id, name, description, type (ModelCategory), price (ModelPrice), and dynamic attributes.
  - Fallback logic for empty `id` using normalized category.

- Add `ModelPrice` to represent monetary values:
  - Supports scaling via `mathPrecision` and `CurrencyEnum` (COP, USD, MXN, etc.).
  - Provides `decimalAmount` for safe precision conversion.

- Create default constants: `defaultModelItem`, `defaultModelPrice`.

- Add full test coverage for:
  - ModelItem: roundtrip, copyWith, fallback ID, equality/hashCode, toString.
  - ModelPrice: decimal math, currency fallback, roundtrip, copyWith.

🏷️ Types are immutable and compatible with Firestore serialization. 🧪 All tests pass locally with `flutter test`.

* feat(domain): add ModelItem, ModelPrice, and ModelAttribute with type-safe attributes and tests

- 🔖 Add `ModelAttribute<T>` (alias for `AttributeModel<T>`):
  - Generic attributes with Firestore-compatible types only.
  - Introduces `from<T>()` helper for safe typed construction.
  - Includes validation to ensure only supported types are allowed.

- 🔬 Tests:
  - `model_item_test.dart`: Roundtrip, fallback ID, equality, copyWith.
  - `model_price_test.dart`: Roundtrip, decimal logic, fallback currency, copyWith.
  - `attribute_model_test.dart`: from<T>(), type safety, roundtrip, equality.

🔒 All models are immutable, extensible, and safe for serialization in Firestore-based systems.

* feat(domain): Updated ModelAttribute.

* feat(domain): model price completed and reviewed

* docs(item): clarify immutability and id fallback in ModelItem

- Document read-only attributes and runtime throw on mutation.
- Reiterate id fallback to normalized category in toJson().
- Keep JSON keys stable via ModelItemEnum.name.

* fix(store): correct address JSON serialization and equality contract

- Serialize address with address.toJson() instead of toString().
- Remove hashCode check from operator== (contract fix).
- Use Object.hash for stable hashing.
- Update DartDoc with runnable example and explicit contracts.

* docs(store): add pet store end-to-end example (single-file)

Show UI → AppManager → Bloc → UseCase → Repository → Gateway → Service using StoreModel, ModelItem, ModelPrice, ModelCategory, FinancialMovementModel, and LedgerModel. Align financial precision with ModelPrice (2). No external packages; ready-to-copy single-file demo.

* docs(changelog): 1.31.2 updated

* refactor: Format code and add type aliases

- Adds `ModelLedger` as a type alias for `LedgerModel`.
- Adds `ModelFinancialMovement` as a type alias for `FinancialMovementModel`.
- Applies standard code formatting across `store_model_example.dart`.

* refactor: Format code and add type aliases