### PR TITLE
Dev/hotfix 1332 extends blochttprequest from blocmodule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,13 @@
 This document follows the guidelines of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.33.2] - 2025-12-07
+### Fixed
+- hotfix para estabilizar el contrato de BlocHttpRequest para garantizar la correcta herencia de BlocModule.
+
 ## [1.33.1] - 2025-12-07
 
-> Hotfix para estabilizar el contrato de `ModelAppVersion` al serializar `buildAt` y permitir `defaultModelAppVersion` totalmente constante.
+- Hotfix para estabilizar el contrato de `ModelAppVersion` al serializar `buildAt` y permitir `defaultModelAppVersion` totalmente constante.
 
 ### Fixed
 - `ModelAppVersion` ahora persiste `buildAt` como cadena ISO-8601 UTC con `kDefaultBuildAtIso` (07 Dic 2025) como valor por defecto, evitando drift entre plataformas y habilitando instancias const en tree-shaking.

--- a/lib/domain/blocs/bloc_http_request.dart
+++ b/lib/domain/blocs/bloc_http_request.dart
@@ -64,12 +64,15 @@ part of 'package:jocaagura_domain/jocaagura_domain.dart';
 ///   true,
 /// );
 /// ```
-class BlocHttpRequest {
+class BlocHttpRequest extends BlocModule {
   /// Creates a new [BlocHttpRequest] with the given [facade].
   BlocHttpRequest(this._facade) : _bloc = BlocGeneral<Set<String>>(<String>{});
 
   /// Facade that groups all HTTP-related use cases.
   final FacadeHttpRequestUsecases _facade;
+
+  /// BLoC identifier (useful for logs/registry).
+  static const String name = 'blocHttpRequest';
 
   /// Central reactive container for all **active** HTTP requests.
   ///
@@ -273,6 +276,7 @@ class BlocHttpRequest {
   }
 
   /// Disposes the internal [BlocGeneral].
+  @override
   void dispose() {
     _bloc.dispose();
   }


### PR DESCRIPTION
## [1.33.2] - 2025-12-07
### Fixed
- hotfix para estabilizar el contrato de BlocHttpRequest para garantizar la correcta herencia de BlocModule.
