### PR TITLE
Publish version 1.35.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,70 @@
 This document follows the guidelines of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.35.0] - 2025-12-18
+
+### Added
+
+* Added `ModelCompleteFlow`, a new immutable domain model to represent a complete deterministic diagram composed of multiple `ModelFlowStep` items.
+* Added `CompleteFlowEnum` to guarantee stable JSON keys via `enum.name` for `ModelCompleteFlow`.
+* Added `defaultModelCompleteFlow` as a safe fallback/testing instance.
+
+### Features
+
+* Implemented canonical **Map-based** storage and JSON contract: `stepsByIndex` (`Map<int, ModelFlowStep>`), serialized as a JSON map keyed by step index as **string** (e.g., `"10"`).
+* Implemented deterministic, **roundtrip-safe** JSON serialization/deserialization:
+
+    * Defensive parsing using `Utils.*FromDynamic`.
+    * Stable emission order using `stepsSorted` (sorted by index).
+    * Lenient `fromJson` that never throws and applies safe defaults.
+
+### Immutability
+
+* Ensured deep immutability:
+
+    * `stepsByIndex` is stored as `Map<int, ModelFlowStep>.unmodifiable`.
+    * Inserted/updated steps are normalized through `ModelCompleteFlow.asImmutableStep(...)` (internally leveraging `ModelFlowStep.immutable`).
+
+### Helpers
+
+* Added ergonomic helpers for diagram manipulation (immutable copy semantics):
+
+    * `stepsSorted` for stable UI/export ordering.
+    * `entryIndex` to determine the diagram entry point (smallest index, or `-1` if empty).
+    * `stepAt(int index)` to retrieve a step by index.
+    * `upsertStep(ModelFlowStep step)` to insert/update by `step.index`.
+    * `removeStepAt(int index)` and `removeStep(ModelFlowStep step)` to delete steps.
+
+### Behavior and Contracts
+
+* Enforced END semantics:
+
+    * Steps with `index < 0` (including `-1`) are ignored and not stored.
+    * `index == -1` remains reserved exclusively as an END target for routing.
+
+### Equality & Hashing
+
+* Added value-based equality and hashing for `ModelCompleteFlow`:
+
+    * `operator ==` compares `name`, `description`, and deep equality for `stepsByIndex` via `Utils.deepEqualsDynamic`.
+    * `hashCode` uses `Object.hash(...)` plus `Utils.deepHash(stepsByIndex)`.
+
+### Documentation
+
+* Added comprehensive DartDoc to `ModelCompleteFlow` including usage guidance, immutability guarantees, JSON contract shape, and an executable `main()` example.
+
+### Tests
+
+* Added unit tests for `ModelCompleteFlow` covering:
+
+    * Map-based JSON roundtrip (toJson/fromJson).
+    * END semantics (`index < 0` ignored).
+    * Deep immutability (unmodifiable collections).
+    * `copyWith()` returning the same instance when no changes are requested.
+    * `upsertStep`/`removeStepAt` behaviors (including no-op returning `this`).
+    * `entryIndex`, `stepsSorted`, and `hashCode` consistency.
+
+
 ## [1.34.0] - 2025-12-08
 
 > **Release acumulada.** Consolida los cambios de **1.33.1** → **1.33.3** sin adiciones extra.  

--- a/example/lib/either_flow_example.dart
+++ b/example/lib/either_flow_example.dart
@@ -1,0 +1,435 @@
+import 'package:flutter/material.dart';
+import 'package:jocaagura_domain/jocaagura_domain.dart';
+
+void main() => runApp(const JgFlowEducationDemoApp());
+
+/// ---------------------------------------------------------------------------
+/// Flutter example: How to use a new model (ModelCompleteFlow) with BlocGeneral
+/// ---------------------------------------------------------------------------
+///
+/// This demo shows the full "jocaagura style" loop:
+/// 1) Create a deeply immutable model with `.immutable(...)`
+/// 2) Hold it as single source of truth using `BlocGeneral<ModelCompleteFlow>`
+/// 3) Mutate only by emitting new values (upsert/remove/copyWith)
+/// 4) Export/import JSON snapshots (roundtrip) to prove stability
+///
+/// Notes:
+/// - No external packages.
+/// - UI uses StreamBuilder to listen to the bloc.
+/// - END semantics: step.index == -1 is reserved; cannot be stored as a step.
+/// ---------------------------------------------------------------------------
+
+class JgFlowEducationDemoApp extends StatelessWidget {
+  const JgFlowEducationDemoApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Jocaagura Flow Demo',
+      theme: ThemeData(useMaterial3: true, colorSchemeSeed: Colors.indigo),
+      home: const CompleteFlowHomePage(),
+    );
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Page: ModelCompleteFlow + BlocGeneral demo
+// -----------------------------------------------------------------------------
+
+class CompleteFlowHomePage extends StatefulWidget {
+  const CompleteFlowHomePage({super.key});
+
+  @override
+  State<CompleteFlowHomePage> createState() => _CompleteFlowHomePageState();
+}
+
+class _CompleteFlowHomePageState extends State<CompleteFlowHomePage> {
+  late final BlocGeneral<ModelCompleteFlow> _flowBloc;
+
+  @override
+  void initState() {
+    super.initState();
+
+    // 1) Create the BLoC (single source of truth).
+    _flowBloc = BlocGeneral<ModelCompleteFlow>(defaultModelCompleteFlow);
+
+    // 2) Hydrate an initial diagram (deeply immutable).
+    _flowBloc.value = _seedAuthFlow();
+  }
+
+  @override
+  void dispose() {
+    // If your BlocGeneral exposes dispose, call it.
+    // _flowBloc.dispose();
+    super.dispose();
+  }
+
+  ModelCompleteFlow _seedAuthFlow() {
+    return ModelCompleteFlow.immutable(
+      name: 'AuthFlow',
+      description: 'Login and session validation diagram.',
+      steps: <ModelFlowStep>[
+        ModelFlowStep.immutable(
+          index: 10,
+          title: 'Authenticate',
+          description:
+              'Runs auth use case and returns Either<ErrorItem, Session>',
+          failureCode: 'AUTH_FAILED',
+          nextOnSuccessIndex: 11,
+          nextOnFailureIndex: -1,
+          constraints: const <String>['requiresInternet'],
+          cost: const <String, double>{'latencyMs': 250, 'networkKb': 12.5},
+        ),
+        ModelFlowStep.immutable(
+          index: 11,
+          title: 'Load Profile',
+          description: 'Loads user profile and finishes.',
+          failureCode: 'PROFILE_FAILED',
+          nextOnSuccessIndex: -1,
+          nextOnFailureIndex: -1,
+          cost: const <String, double>{'dbReadsCount': 2},
+        ),
+      ],
+    );
+  }
+
+  void _renameFlow() {
+    final ModelCompleteFlow current = _flowBloc.value;
+    _flowBloc.value = current.copyWith(name: '${current.name}_v2');
+  }
+
+  void _upsertNewStep() {
+    final ModelCompleteFlow current = _flowBloc.value;
+
+    // In a real app, this comes from a form.
+    // Upsert means: create if missing, update if exists.
+    final ModelFlowStep newStep = ModelFlowStep.immutable(
+      index: 20,
+      title: 'Audit Log',
+      description: 'Sends audit event and finishes.',
+      failureCode: 'AUDIT_FAILED',
+      nextOnSuccessIndex: -1,
+      nextOnFailureIndex: -1,
+      constraints: const <String>['requiresInternet'],
+      cost: const <String, double>{'latencyMs': 50, 'networkKb': 2},
+    );
+
+    _flowBloc.value = current.upsertStep(newStep);
+  }
+
+  void _updateExistingStep10() {
+    final ModelCompleteFlow current = _flowBloc.value;
+    final ModelFlowStep? step10 = current.stepAt(10);
+    if (step10 == null) {
+      return;
+    }
+
+    // We change only what we need, and upsert the new step.
+    final ModelFlowStep updated = step10.copyWith(
+      title: 'Authenticate (v2)',
+      cost: <String, double>{
+        ...step10.cost,
+        'latencyMs': 300, // "real units"
+      },
+    );
+
+    _flowBloc.value = current.upsertStep(updated);
+  }
+
+  void _removeEntryStep() {
+    final ModelCompleteFlow current = _flowBloc.value;
+    if (current.entryIndex < 0) {
+      return;
+    }
+
+    _flowBloc.value = current.removeStepAt(current.entryIndex);
+  }
+
+  void _exportJson(BuildContext context) {
+    final Map<String, dynamic> json = _flowBloc.value.toJson();
+    final String pretty = json.toString();
+
+    showDialog<void>(
+      context: context,
+      builder: (_) => AlertDialog(
+        title: const Text('Export JSON (roundtrip-safe)'),
+        content: SingleChildScrollView(
+          child: Text(pretty, style: const TextStyle(fontSize: 12)),
+        ),
+        actions: <Widget>[
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('Close'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _importRoundtrip(BuildContext context) {
+    // Demonstrates the "contract proof":
+    // export -> fromJson -> equals
+    final ModelCompleteFlow current = _flowBloc.value;
+    final Map<String, dynamic> json = current.toJson();
+    final ModelCompleteFlow restored = ModelCompleteFlow.fromJson(json);
+
+    final bool ok =
+        restored == current && restored.hashCode == current.hashCode;
+
+    _flowBloc.value = restored;
+
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(
+          ok ? 'Roundtrip OK ✅ (== and hashCode)' : 'Roundtrip mismatch ❌',
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return StreamBuilder<ModelCompleteFlow>(
+      // The BLoC is the only source of truth.
+      stream: _flowBloc.stream,
+      initialData: _flowBloc.value,
+      builder:
+          (BuildContext context, AsyncSnapshot<ModelCompleteFlow> snapshot) {
+        final ModelCompleteFlow flow =
+            snapshot.data ?? defaultModelCompleteFlow;
+        final List<ModelFlowStep> steps = flow.stepsSorted;
+
+        return Scaffold(
+          appBar: AppBar(
+            title: Text(flow.name.isEmpty ? 'Flow Demo' : flow.name),
+            actions: <Widget>[
+              IconButton(
+                tooltip: 'Export JSON',
+                icon: const Icon(Icons.code),
+                onPressed: () => _exportJson(context),
+              ),
+              IconButton(
+                tooltip: 'Import Roundtrip',
+                icon: const Icon(Icons.cached),
+                onPressed: () => _importRoundtrip(context),
+              ),
+            ],
+          ),
+          body: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Text(
+                  flow.name.isEmpty ? 'Unnamed Flow' : flow.name,
+                  style: Theme.of(context).textTheme.headlineSmall,
+                ),
+                const SizedBox(height: 6),
+                Text(
+                  flow.description.isEmpty
+                      ? 'No description.'
+                      : flow.description,
+                ),
+                const SizedBox(height: 12),
+                _FlowStatsCard(flow: flow),
+                const SizedBox(height: 12),
+                Text('Steps', style: Theme.of(context).textTheme.titleMedium),
+                const SizedBox(height: 8),
+                Expanded(
+                  child: steps.isEmpty
+                      ? const Center(child: Text('No steps yet.'))
+                      : ListView.separated(
+                          itemCount: steps.length,
+                          separatorBuilder: (_, __) => const Divider(height: 1),
+                          itemBuilder: (_, int i) => _FlowStepTile(
+                            step: steps[i],
+                            onRemove: () => _flowBloc.value =
+                                flow.removeStepAt(steps[i].index),
+                          ),
+                        ),
+                ),
+                const SizedBox(height: 12),
+                _HelperNote(flow: flow),
+              ],
+            ),
+          ),
+          floatingActionButton: _FabMenu(
+            onRename: _renameFlow,
+            onUpsertNew: _upsertNewStep,
+            onUpdateStep10: _updateExistingStep10,
+            onRemoveEntry: _removeEntryStep,
+          ),
+        );
+      },
+    );
+  }
+}
+
+// -----------------------------------------------------------------------------
+// UI Components
+// -----------------------------------------------------------------------------
+
+class _FlowStatsCard extends StatelessWidget {
+  const _FlowStatsCard({required this.flow});
+
+  final ModelCompleteFlow flow;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      elevation: 1,
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Row(
+          children: <Widget>[
+            const Icon(Icons.account_tree_outlined, size: 28),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  Text(
+                    'Entry index: ${flow.entryIndex}',
+                    style: const TextStyle(fontWeight: FontWeight.w600),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    'Steps: ${flow.stepsByIndex.length} • JSON keys are indices as strings',
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _FlowStepTile extends StatelessWidget {
+  const _FlowStepTile({
+    required this.step,
+    required this.onRemove,
+  });
+
+  final ModelFlowStep step;
+  final VoidCallback onRemove;
+
+  @override
+  Widget build(BuildContext context) {
+    final String costLabel = step.cost.isEmpty
+        ? '—'
+        : step.cost.entries
+            .map((MapEntry<String, double> e) => '${e.key}: ${e.value}')
+            .join(' • ');
+
+    return ListTile(
+      leading: CircleAvatar(child: Text('${step.index}')),
+      title: Text(step.title),
+      subtitle: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          const SizedBox(height: 4),
+          Text(step.description),
+          const SizedBox(height: 6),
+          Text(
+            'Failure code: ${step.failureCode}',
+            style: const TextStyle(fontSize: 12),
+          ),
+          Text(
+            'On Right → ${step.nextOnSuccessIndex}  |  On Left → ${step.nextOnFailureIndex}',
+            style: const TextStyle(fontSize: 12),
+          ),
+          const SizedBox(height: 6),
+          Text(
+            'Cost (real units): $costLabel',
+            style: const TextStyle(fontSize: 12),
+          ),
+        ],
+      ),
+      trailing: IconButton(
+        tooltip: 'Remove step',
+        icon: const Icon(Icons.delete_outline),
+        onPressed: onRemove,
+      ),
+    );
+  }
+}
+
+class _FabMenu extends StatelessWidget {
+  const _FabMenu({
+    required this.onRename,
+    required this.onUpsertNew,
+    required this.onUpdateStep10,
+    required this.onRemoveEntry,
+  });
+
+  final VoidCallback onRename;
+  final VoidCallback onUpsertNew;
+  final VoidCallback onUpdateStep10;
+  final VoidCallback onRemoveEntry;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: <Widget>[
+        FloatingActionButton.small(
+          heroTag: 'rename',
+          onPressed: onRename,
+          tooltip: 'Rename flow',
+          child: const Icon(Icons.drive_file_rename_outline),
+        ),
+        const SizedBox(height: 10),
+        FloatingActionButton.small(
+          heroTag: 'upsertNew',
+          onPressed: onUpsertNew,
+          tooltip: 'Upsert new step',
+          child: const Icon(Icons.add),
+        ),
+        const SizedBox(height: 10),
+        FloatingActionButton.small(
+          heroTag: 'update10',
+          onPressed: onUpdateStep10,
+          tooltip: 'Update step #10',
+          child: const Icon(Icons.edit),
+        ),
+        const SizedBox(height: 10),
+        FloatingActionButton.small(
+          heroTag: 'removeEntry',
+          onPressed: onRemoveEntry,
+          tooltip: 'Remove entry step',
+          child: const Icon(Icons.remove_circle_outline),
+        ),
+      ],
+    );
+  }
+}
+
+class _HelperNote extends StatelessWidget {
+  const _HelperNote({required this.flow});
+
+  final ModelCompleteFlow flow;
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        border: Border.all(color: Theme.of(context).dividerColor),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Text(
+          'Tip: In our approach, the model is a value object (immutable + JSON roundtrip).\n'
+          'The BlocGeneral<ModelCompleteFlow> is the single source of truth.\n'
+          'Mutations are expressed as new values via copyWith/upsert/remove.\n'
+          '\n'
+          'Current entryIndex: ${flow.entryIndex} • steps: ${flow.stepsByIndex.length}',
+          textAlign: TextAlign.center,
+          style: const TextStyle(fontSize: 12),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/domain/either_flow/model_complete_flow.dart
+++ b/lib/domain/either_flow/model_complete_flow.dart
@@ -1,0 +1,347 @@
+part of 'package:jocaagura_domain/jocaagura_domain.dart';
+
+/// Enumerates the serialized fields of [ModelCompleteFlow].
+enum CompleteFlowEnum {
+  name,
+  description,
+
+  /// Canonical storage/contract: map keyed by step index (as string in JSON).
+  stepsByIndex,
+}
+
+/// Default instance of [ModelCompleteFlow] for fallback/testing.
+const ModelCompleteFlow defaultModelCompleteFlow = ModelCompleteFlow(
+  name: '',
+  description: '',
+  stepsByIndex: <int, ModelFlowStep>{},
+);
+
+/// Represent a complete deterministic diagram composed of multiple [ModelFlowStep] items.
+///
+/// Contract and storage:
+/// - Steps are stored in [stepsByIndex], keyed by [ModelFlowStep.index].
+/// - JSON uses the same structure: `stepsByIndex` is a map whose keys are the step
+///   indices encoded as strings (e.g. `"10"`, `"11"`).
+///
+/// END semantics:
+/// - `index == -1` is reserved for END targets only.
+/// - Steps with `index < 0` are ignored (not stored).
+///
+/// Immutability:
+/// - This model is deeply immutable: [stepsByIndex] is unmodifiable.
+/// - All inserted steps are normalized to [ModelFlowStep.immutable].
+///
+/// JSON roundtrip is guaranteed by:
+/// - Defensive parsing with safe defaults
+/// - Stable serialization order (sorted by index)
+///
+/// Example:
+/// ```dart
+/// void main() {
+///   final ModelCompleteFlow flow = ModelCompleteFlow.immutable(
+///     name: 'AuthFlow',
+///     description: 'Login and session validation diagram.',
+///     steps: <ModelFlowStep>[
+///       ModelFlowStep.immutable(
+///         index: 10,
+///         title: 'Authenticate',
+///         description: 'Runs auth use case',
+///         failureCode: 'AUTH_FAILED',
+///         nextOnSuccessIndex: 11,
+///         nextOnFailureIndex: -1,
+///         cost: <String, double>{'latencyMs': 250},
+///       ),
+///     ],
+///   );
+///
+///   final Map<String, dynamic> json = flow.toJson();
+///   final ModelCompleteFlow roundtrip = ModelCompleteFlow.fromJson(json);
+///   assert(flow == roundtrip);
+/// }
+/// ```
+@immutable
+class ModelCompleteFlow extends Model {
+  /// Creates a flow instance.
+  ///
+  /// Note: this constructor expects already-frozen collections.
+  const ModelCompleteFlow({
+    required this.name,
+    required this.description,
+    required this.stepsByIndex,
+  });
+
+  /// Creates a deeply immutable [ModelCompleteFlow] from a list of steps.
+  ///
+  /// Duplicate indices are resolved by "last write wins".
+  factory ModelCompleteFlow.immutable({
+    required String name,
+    required String description,
+    List<ModelFlowStep> steps = const <ModelFlowStep>[],
+  }) {
+    final Map<int, ModelFlowStep> tmp = <int, ModelFlowStep>{};
+
+    for (final ModelFlowStep step in steps) {
+      if (step.index < 0) {
+        // -1 is END-only; do not store as a real step.
+        continue;
+      }
+      tmp[step.index] = _asImmutableStep(step);
+    }
+
+    return ModelCompleteFlow(
+      name: name,
+      description: description,
+      stepsByIndex: Map<int, ModelFlowStep>.unmodifiable(tmp),
+    );
+  }
+
+  /// Creates a deeply immutable [ModelCompleteFlow] from a map keyed by step index.
+  ///
+  /// Steps with `index < 0` are ignored.
+  factory ModelCompleteFlow.immutableFromMap({
+    required String name,
+    required String description,
+    Map<int, ModelFlowStep> stepsByIndex = const <int, ModelFlowStep>{},
+  }) {
+    final Map<int, ModelFlowStep> tmp = <int, ModelFlowStep>{};
+
+    for (final MapEntry<int, ModelFlowStep> entry in stepsByIndex.entries) {
+      if (entry.key < 0) {
+        continue;
+      }
+      tmp[entry.key] = _asImmutableStep(entry.value);
+    }
+
+    return ModelCompleteFlow(
+      name: name,
+      description: description,
+      stepsByIndex: Map<int, ModelFlowStep>.unmodifiable(tmp),
+    );
+  }
+
+  /// Creates a [ModelCompleteFlow] from a JSON-like map.
+  ///
+  /// This parser is lenient and never throws; it applies safe defaults.
+  ///
+  /// Expected JSON shape:
+  /// ```json
+  /// {
+  ///   "name": "AuthFlow",
+  ///   "description": "...",
+  ///   "stepsByIndex": {
+  ///     "10": { ... ModelFlowStep JSON ... },
+  ///     "11": { ... }
+  ///   }
+  /// }
+  /// ```
+  factory ModelCompleteFlow.fromJson(Map<String, dynamic> json) {
+    final String nameTmp =
+        Utils.getStringFromDynamic(json[CompleteFlowEnum.name.name]);
+    final String descriptionTmp =
+        Utils.getStringFromDynamic(json[CompleteFlowEnum.description.name]);
+
+    final dynamic rawStepsByIndex = json[CompleteFlowEnum.stepsByIndex.name];
+    final Map<int, ModelFlowStep> tmp = <int, ModelFlowStep>{};
+
+    if (rawStepsByIndex is Map) {
+      for (final MapEntry<dynamic, dynamic> entry in rawStepsByIndex.entries) {
+        final int indexKey = Utils.getIntegerFromDynamic(entry.key);
+        if (indexKey < 0) {
+          // END-only; ignore.
+          continue;
+        }
+
+        final dynamic value = entry.value;
+
+        if (value is Map<String, dynamic>) {
+          final ModelFlowStep step = ModelFlowStep.fromJson(value);
+          if (step.index < 0) {
+            continue;
+          }
+          tmp[step.index] =
+              step; // fromJson already returns immutable in your design
+          continue;
+        }
+
+        if (value is Map) {
+          final Map<String, dynamic> casted = <String, dynamic>{};
+          for (final MapEntry<dynamic, dynamic> e in value.entries) {
+            casted[e.key.toString()] = e.value;
+          }
+          final ModelFlowStep step = ModelFlowStep.fromJson(casted);
+          if (step.index < 0) {
+            continue;
+          }
+          tmp[step.index] = step;
+        }
+      }
+    }
+
+    return ModelCompleteFlow(
+      name: nameTmp,
+      description: descriptionTmp,
+      stepsByIndex: Map<int, ModelFlowStep>.unmodifiable(tmp),
+    );
+  }
+
+  /// Flow label (human and/or machine).
+  final String name;
+
+  /// Diagram description (human and/or machine).
+  final String description;
+
+  /// Steps keyed by [ModelFlowStep.index]. This map is unmodifiable.
+  final Map<int, ModelFlowStep> stepsByIndex;
+
+  /// Returns steps sorted by index (stable view for UI/exports).
+  List<ModelFlowStep> get stepsSorted {
+    final List<int> keys = stepsByIndex.keys.toList(growable: false)..sort();
+    final List<ModelFlowStep> out = <ModelFlowStep>[];
+    for (final int k in keys) {
+      final ModelFlowStep? step = stepsByIndex[k];
+      if (step != null) {
+        out.add(step);
+      }
+    }
+    return List<ModelFlowStep>.unmodifiable(out);
+  }
+
+  /// Returns the entry index for this flow.
+  ///
+  /// Convention: the smallest index in [stepsByIndex], or `-1` if empty.
+  int get entryIndex {
+    if (stepsByIndex.isEmpty) {
+      return -1;
+    }
+    final List<int> keys = stepsByIndex.keys.toList(growable: false)..sort();
+    return keys.first;
+  }
+
+  /// Gets a step by index (or `null`).
+  ModelFlowStep? stepAt(int index) => stepsByIndex[index];
+
+  /// Returns a deeply immutable copy upserting [step] by its [ModelFlowStep.index].
+  ///
+  /// If `step.index < 0`, this operation is ignored and returns `this`.
+  ModelCompleteFlow upsertStep(ModelFlowStep step) {
+    if (step.index < 0) {
+      return this;
+    }
+
+    final ModelFlowStep frozen = _asImmutableStep(step);
+    final ModelFlowStep? current = stepsByIndex[step.index];
+
+    if (current == frozen) {
+      return this;
+    }
+
+    final Map<int, ModelFlowStep> tmp = <int, ModelFlowStep>{}
+      ..addAll(stepsByIndex);
+    tmp[step.index] = frozen;
+
+    return ModelCompleteFlow(
+      name: name,
+      description: description,
+      stepsByIndex: Map<int, ModelFlowStep>.unmodifiable(tmp),
+    );
+  }
+
+  /// Returns a deeply immutable copy removing the step at [index].
+  ///
+  /// If `index < 0` or it doesn't exist, returns `this`.
+  ModelCompleteFlow removeStepAt(int index) {
+    if (index < 0 || !stepsByIndex.containsKey(index)) {
+      return this;
+    }
+
+    final Map<int, ModelFlowStep> tmp = <int, ModelFlowStep>{}
+      ..addAll(stepsByIndex);
+    tmp.remove(index);
+
+    return ModelCompleteFlow(
+      name: name,
+      description: description,
+      stepsByIndex: Map<int, ModelFlowStep>.unmodifiable(tmp),
+    );
+  }
+
+  /// Convenience: removes by step index.
+  ModelCompleteFlow removeStep(ModelFlowStep step) => removeStepAt(step.index);
+
+  /// Copy with optional new values.
+  ///
+  /// If a parameter is `null`, the current value is kept.
+  @override
+  ModelCompleteFlow copyWith({
+    String? name,
+    String? description,
+    Map<int, ModelFlowStep>? stepsByIndex,
+  }) {
+    final bool noChanges =
+        name == null && description == null && stepsByIndex == null;
+    if (noChanges) {
+      return this;
+    }
+
+    return ModelCompleteFlow.immutableFromMap(
+      name: name ?? this.name,
+      description: description ?? this.description,
+      stepsByIndex: stepsByIndex ?? this.stepsByIndex,
+    );
+  }
+
+  /// Converts this model into a JSON map (roundtrip-safe).
+  ///
+  /// The `stepsByIndex` map keys are serialized as strings, and steps are emitted
+  /// in a stable order (sorted by index).
+  @override
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> byIndex = <String, dynamic>{};
+
+    for (final ModelFlowStep step in stepsSorted) {
+      byIndex[step.index.toString()] = step.toJson();
+    }
+
+    return <String, dynamic>{
+      CompleteFlowEnum.name.name: name,
+      CompleteFlowEnum.description.name: description,
+      CompleteFlowEnum.stepsByIndex.name: byIndex,
+    };
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+
+    return other is ModelCompleteFlow &&
+        runtimeType == other.runtimeType &&
+        name == other.name &&
+        description == other.description &&
+        Utils.deepEqualsDynamic(stepsByIndex, other.stepsByIndex);
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        name,
+        description,
+        Utils.deepHash(stepsByIndex),
+      );
+
+  @override
+  String toString() => '${toJson()}';
+
+  static ModelFlowStep _asImmutableStep(ModelFlowStep step) {
+    return ModelFlowStep.immutable(
+      index: step.index,
+      title: step.title,
+      description: step.description,
+      failureCode: step.failureCode,
+      nextOnSuccessIndex: step.nextOnSuccessIndex,
+      nextOnFailureIndex: step.nextOnFailureIndex,
+      constraints: step.constraints,
+      cost: step.cost,
+    );
+  }
+}

--- a/lib/domain/either_flow/model_flow_step.dart
+++ b/lib/domain/either_flow/model_flow_step.dart
@@ -1,0 +1,291 @@
+part of 'package:jocaagura_domain/jocaagura_domain.dart';
+
+/// Enumerates the serialized fields of [ModelFlowStep].
+enum FlowStepEnum {
+  indexNumber,
+  title,
+  description,
+  failureCode,
+  nextOnSuccessIndex,
+  nextOnFailureIndex,
+  constraints,
+  cost,
+}
+
+/// Default instance of [ModelFlowStep] for fallback/testing.
+///
+/// It represents a minimal END step with safe defaults.
+const ModelFlowStep defaultModelFlowStepModel = ModelFlowStep(
+  index: 0,
+  title: '',
+  description: '',
+  failureCode: 'UNKNOWN',
+  nextOnSuccessIndex: -1,
+  nextOnFailureIndex: -1,
+);
+
+/// Represent a deterministic flow step that routes by Either outcome.
+///
+/// A step declares:
+/// - Where to go on `Right` (success) via [nextOnSuccessIndex]
+/// - Where to go on `Left`  (failure) via [nextOnFailureIndex]
+/// - A standardized [failureCode] for traceability
+///
+/// `cost` is a per-metric map expressed in **real units**.
+/// The key must encode the unit (e.g. `latencyMs`, `networkKb`, `dbReadsCount`),
+/// and the value is the numeric measurement in that unit.
+///
+/// Immutability notes:
+/// - The default `const` constructor keeps fields `final`, but it does not deep-freeze
+///   incoming collections if mutable instances are provided.
+/// - Use [ModelFlowStep.immutable] to obtain a deeply immutable instance (unmodifiable collections).
+///
+/// JSON roundtrip is guaranteed by:
+/// - Defensive parsing (`Utils.*FromDynamic`)
+/// - Cost values normalized to finite **non-negative** doubles (invalid => `0.0`)
+///
+/// Example:
+/// ```dart
+/// void main() {
+///   final ModelFlowStep step = ModelFlowStep.immutable(
+///     index: 10,
+///     title: 'Authenticate',
+///     description: 'Runs auth use case and returns Either<ErrorItem, Session>',
+///     failureCode: 'AUTH_FAILED',
+///     nextOnSuccessIndex: 11,
+///     nextOnFailureIndex: 99,
+///     constraints: <String>['requiresInternet'],
+///     cost: <String, double>{
+///       'latencyMs': 250,
+///       'networkKb': 12.5,
+///       'dbReadsCount': 2,
+///     },
+///   );
+///
+///   final Map<String, dynamic> json = step.toJson();
+///   final ModelFlowStep roundtrip = ModelFlowStep.fromJson(json);
+///   assert(step == roundtrip);
+/// }
+/// ```
+@immutable
+class ModelFlowStep extends Model {
+  /// Creates a deterministic flow step.
+  ///
+  /// Note: this constructor does not deep-freeze collection arguments.
+  /// Prefer [ModelFlowStep.immutable] when you need unmodifiable collections.
+  const ModelFlowStep({
+    required this.index,
+    required this.title,
+    required this.description,
+    required this.failureCode,
+    required this.nextOnSuccessIndex,
+    required this.nextOnFailureIndex,
+    this.constraints = const <String>[],
+    this.cost = const <String, double>{},
+  });
+
+  /// Creates a deeply immutable [ModelFlowStep].
+  ///
+  /// This factory copies and wraps [constraints] and [cost] into unmodifiable
+  /// collections, so the instance remains stable even if the caller mutates
+  /// their original inputs after construction.
+  ///
+  /// Cost normalization:
+  /// - Non-finite values (NaN/Infinity) become `0.0`
+  /// - Negative values become `0.0`
+  factory ModelFlowStep.immutable({
+    required int index,
+    required String title,
+    required String description,
+    required String failureCode,
+    required int nextOnSuccessIndex,
+    required int nextOnFailureIndex,
+    List<String> constraints = const <String>[],
+    Map<String, double> cost = const <String, double>{},
+  }) {
+    final List<String> frozenConstraints =
+        List<String>.unmodifiable(List<String>.from(constraints));
+
+    final Map<String, double> normalizedCost = <String, double>{};
+    for (final MapEntry<String, double> entry in cost.entries) {
+      final double value = entry.value;
+      final double normalized = value.isFinite && value >= 0.0 ? value : 0.0;
+      normalizedCost[entry.key] = normalized;
+    }
+
+    final Map<String, double> frozenCost =
+        Map<String, double>.unmodifiable(normalizedCost);
+
+    return ModelFlowStep(
+      index: index,
+      title: title,
+      description: description,
+      failureCode: failureCode,
+      nextOnSuccessIndex: nextOnSuccessIndex,
+      nextOnFailureIndex: nextOnFailureIndex,
+      constraints: frozenConstraints,
+      cost: frozenCost,
+    );
+  }
+
+  /// Creates a [ModelFlowStep] from a JSON-like map.
+  ///
+  /// This parser is lenient and never throws; it applies safe defaults.
+  factory ModelFlowStep.fromJson(Map<String, dynamic> json) {
+    final int indexTmp =
+        Utils.getIntegerFromDynamic(json[FlowStepEnum.indexNumber.name]);
+    final String titleTmp =
+        Utils.getStringFromDynamic(json[FlowStepEnum.title.name]);
+    final String descriptionTmp =
+        Utils.getStringFromDynamic(json[FlowStepEnum.description.name]);
+
+    final String failureCodeRaw =
+        Utils.getStringFromDynamic(json[FlowStepEnum.failureCode.name]);
+    final String failureCodeTmp = failureCodeRaw.isEmpty
+        ? defaultModelFlowStepModel.failureCode
+        : failureCodeRaw;
+
+    final int nextOnSuccessTmp =
+        Utils.getIntegerFromDynamic(json[FlowStepEnum.nextOnSuccessIndex.name]);
+    final int nextOnFailureTmp =
+        Utils.getIntegerFromDynamic(json[FlowStepEnum.nextOnFailureIndex.name]);
+
+    final List<String> constraintsTmp =
+        Utils.stringListFromDynamic(json[FlowStepEnum.constraints.name])
+            .cast<String>();
+
+    final Map<dynamic, dynamic> costRaw =
+        Utils.mapFromDynamic(json[FlowStepEnum.cost.name])
+            .cast<dynamic, dynamic>();
+
+    final Map<String, double> costTmp = <String, double>{};
+    for (final MapEntry<dynamic, dynamic> entry in costRaw.entries) {
+      final String key = entry.key.toString();
+      final double parsed = Utils.getDouble(entry.value, 0.0);
+      final double normalized = parsed.isFinite && parsed >= 0.0 ? parsed : 0.0;
+      costTmp[key] = normalized;
+    }
+
+    return ModelFlowStep.immutable(
+      index: indexTmp,
+      title: titleTmp,
+      description: descriptionTmp,
+      failureCode: failureCodeTmp,
+      nextOnSuccessIndex: nextOnSuccessTmp,
+      nextOnFailureIndex: nextOnFailureTmp,
+      constraints: constraintsTmp,
+      cost: costTmp,
+    );
+  }
+
+  /// Step unique identifier inside a flow.
+  final int index;
+
+  /// Short label for architects and UI mapping.
+  final String title;
+
+  /// Human-readable description of what this step does.
+  final String description;
+
+  /// Standardized failure code for traceability (ideally aligned to ErrorItem.code).
+  final String failureCode;
+
+  /// Next index when execution returns `Right`. Use `-1` to represent END.
+  final int nextOnSuccessIndex;
+
+  /// Next index when execution returns `Left`. Use `-1` to represent END.
+  final int nextOnFailureIndex;
+
+  /// Optional constraints (e.g., "requiresInternet", "role:admin").
+  final List<String> constraints;
+
+  /// Optional per-metric costs expressed in real units.
+  ///
+  /// Keys should encode the unit (e.g., `latencyMs`, `networkKb`, `dbReadsCount`).
+  final Map<String, double> cost;
+
+  /// Creates a copy of this [ModelFlowStep] with optional new values.
+  ///
+  /// If a parameter is `null`, the current value is kept.
+  @override
+  ModelFlowStep copyWith({
+    int? index,
+    String? title,
+    String? description,
+    String? failureCode,
+    int? nextOnSuccessIndex,
+    int? nextOnFailureIndex,
+    List<String>? constraints,
+    Map<String, double>? cost,
+  }) {
+    final bool noChanges = index == null &&
+        title == null &&
+        description == null &&
+        failureCode == null &&
+        nextOnSuccessIndex == null &&
+        nextOnFailureIndex == null &&
+        constraints == null &&
+        cost == null;
+    if (noChanges) {
+      return this;
+    }
+    return ModelFlowStep.immutable(
+      index: index ?? this.index,
+      title: title ?? this.title,
+      description: description ?? this.description,
+      failureCode: failureCode ?? this.failureCode,
+      nextOnSuccessIndex: nextOnSuccessIndex ?? this.nextOnSuccessIndex,
+      nextOnFailureIndex: nextOnFailureIndex ?? this.nextOnFailureIndex,
+      constraints: constraints ?? this.constraints,
+      cost: cost ?? this.cost,
+    );
+  }
+
+  /// Converts this model into a JSON map (roundtrip-safe).
+  @override
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      FlowStepEnum.indexNumber.name: index,
+      FlowStepEnum.title.name: title,
+      FlowStepEnum.description.name: description,
+      FlowStepEnum.failureCode.name: failureCode,
+      FlowStepEnum.nextOnSuccessIndex.name: nextOnSuccessIndex,
+      FlowStepEnum.nextOnFailureIndex.name: nextOnFailureIndex,
+      FlowStepEnum.constraints.name: constraints,
+      FlowStepEnum.cost.name: cost,
+    };
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+
+    return other is ModelFlowStep &&
+        runtimeType == other.runtimeType &&
+        index == other.index &&
+        title == other.title &&
+        description == other.description &&
+        failureCode == other.failureCode &&
+        nextOnSuccessIndex == other.nextOnSuccessIndex &&
+        nextOnFailureIndex == other.nextOnFailureIndex &&
+        Utils.listEquals(constraints, other.constraints) &&
+        Utils.deepEqualsDynamic(cost, other.cost);
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        index,
+        title,
+        description,
+        failureCode,
+        nextOnSuccessIndex,
+        nextOnFailureIndex,
+        Utils.listHash(constraints),
+        Utils.deepHash(cost),
+      );
+
+  @override
+  String toString() => '${toJson()}';
+}

--- a/lib/jocaagura_domain.dart
+++ b/lib/jocaagura_domain.dart
@@ -57,9 +57,7 @@ part 'domain/common_errors/session_error_items.dart';
 part 'domain/common_errors/web_socket_error_items.dart';
 part 'domain/configs/ws_db_config.dart';
 part 'domain/connectivity_model.dart';
-
 part 'domain/crud/model_crud_log_entry.dart';
-
 part 'domain/crud/model_crud_metadata.dart';
 part 'domain/death_record_model.dart';
 part 'domain/debouncer.dart';
@@ -75,6 +73,8 @@ part 'domain/education/model_learning_goal.dart';
 part 'domain/education/model_learning_item.dart';
 part 'domain/education/model_performance_indicator.dart';
 part 'domain/either.dart';
+part 'domain/either_flow/model_complete_flow.dart';
+part 'domain/either_flow/model_flow_step.dart';
 part 'domain/entity_bloc.dart';
 part 'domain/entity_provider.dart';
 part 'domain/entity_service.dart';
@@ -89,23 +89,14 @@ part 'domain/gateways/gateway_ws_database.dart';
 part 'domain/graphics/model_graph.dart';
 part 'domain/graphics/model_graph_axis_spec.dart';
 part 'domain/graphics/model_point.dart';
-
 part 'domain/groups/model_group.dart';
-
 part 'domain/groups/model_group_alias.dart';
-
 part 'domain/groups/model_group_config.dart';
-
 part 'domain/groups/model_group_dynamic_membership_rule.dart';
-
 part 'domain/groups/model_group_labels.dart';
-
 part 'domain/groups/model_group_member.dart';
-
 part 'domain/groups/model_group_settings.dart';
-
 part 'domain/groups/model_group_sync_config.dart';
-
 part 'domain/groups/model_group_sync_job.dart';
 part 'domain/http/http_enums.dart';
 part 'domain/http/http_request_errors.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: jocaagura_domain
 description: "A package with domain models for all transversal applications"
 
-version: 1.34.0
+version: 1.35.0
 
 homepage: https://github.com/jocaagura/jocaagura_domain
 repository: https://github.com/jocaagura/jocaagura_domain

--- a/test/domain/either_flow/model_complete_flow_test.dart
+++ b/test/domain/either_flow/model_complete_flow_test.dart
@@ -1,0 +1,549 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jocaagura_domain/jocaagura_domain.dart';
+
+void main() {
+  group('ModelCompleteFlow.immutable()', () {
+    test(
+        'Given steps with negative index When building immutable Then ignores negative-index steps',
+        () {
+      // Arrange
+      final ModelFlowStep valid = ModelFlowStep.immutable(
+        index: 10,
+        title: 'A',
+        description: 'd',
+        failureCode: 'X',
+        nextOnSuccessIndex: -1,
+        nextOnFailureIndex: -1,
+      );
+
+      final ModelFlowStep invalidEnd = ModelFlowStep.immutable(
+        index: -1,
+        title: 'END?',
+        description: 'should not be stored',
+        failureCode: 'END',
+        nextOnSuccessIndex: -1,
+        nextOnFailureIndex: -1,
+      );
+
+      // Act
+      final ModelCompleteFlow flow = ModelCompleteFlow.immutable(
+        name: 'Flow',
+        description: 'Desc',
+        steps: <ModelFlowStep>[invalidEnd, valid],
+      );
+
+      // Assert
+      expect(flow.stepsByIndex.length, equals(1));
+      expect(flow.stepsByIndex.containsKey(10), isTrue);
+      expect(flow.stepsByIndex.containsKey(-1), isFalse);
+    });
+
+    test('Given duplicate indices When building immutable Then last write wins',
+        () {
+      // Arrange
+      final ModelFlowStep first = ModelFlowStep.immutable(
+        index: 10,
+        title: 'First',
+        description: 'd',
+        failureCode: 'X',
+        nextOnSuccessIndex: -1,
+        nextOnFailureIndex: -1,
+      );
+
+      final ModelFlowStep second = ModelFlowStep.immutable(
+        index: 10,
+        title: 'Second',
+        description: 'd',
+        failureCode: 'X',
+        nextOnSuccessIndex: -1,
+        nextOnFailureIndex: -1,
+      );
+
+      // Act
+      final ModelCompleteFlow flow = ModelCompleteFlow.immutable(
+        name: 'Flow',
+        description: 'Desc',
+        steps: <ModelFlowStep>[first, second],
+      );
+
+      // Assert
+      expect(flow.stepsByIndex[10]?.title, equals('Second'));
+    });
+
+    test(
+        'Given immutable flow When mutating stepsByIndex Then throws UnsupportedError',
+        () {
+      // Arrange
+      final ModelCompleteFlow flow = ModelCompleteFlow.immutable(
+        name: 'Flow',
+        description: 'Desc',
+        steps: <ModelFlowStep>[
+          ModelFlowStep.immutable(
+            index: 1,
+            title: 'A',
+            description: 'd',
+            failureCode: 'X',
+            nextOnSuccessIndex: -1,
+            nextOnFailureIndex: -1,
+          ),
+        ],
+      );
+
+      // Assert
+      expect(
+        () => flow.stepsByIndex[2] = flow.stepsByIndex[1]!,
+        throwsUnsupportedError,
+      );
+      expect(() => flow.stepsByIndex.remove(1), throwsUnsupportedError);
+    });
+  });
+
+  group('ModelCompleteFlow.immutableFromMap()', () {
+    test(
+        'Given map containing negative key When building immutableFromMap Then ignores negative keys',
+        () {
+      // Arrange
+      final Map<int, ModelFlowStep> map = <int, ModelFlowStep>{
+        -1: ModelFlowStep.immutable(
+          index: -1,
+          title: 'END?',
+          description: 'no',
+          failureCode: 'END',
+          nextOnSuccessIndex: -1,
+          nextOnFailureIndex: -1,
+        ),
+        2: ModelFlowStep.immutable(
+          index: 2,
+          title: 'Ok',
+          description: 'd',
+          failureCode: 'X',
+          nextOnSuccessIndex: -1,
+          nextOnFailureIndex: -1,
+        ),
+      };
+
+      // Act
+      final ModelCompleteFlow flow = ModelCompleteFlow.immutableFromMap(
+        name: 'Flow',
+        description: 'Desc',
+        stepsByIndex: map,
+      );
+
+      // Assert
+      expect(flow.stepsByIndex.containsKey(-1), isFalse);
+      expect(flow.stepsByIndex.containsKey(2), isTrue);
+    });
+  });
+
+  group('ModelCompleteFlow.fromJson() / toJson()', () {
+    test(
+        'Given JSON with stepsByIndex map When parsing Then builds flow and keeps immutability',
+        () {
+      // Arrange
+      final Map<String, dynamic> json = <String, dynamic>{
+        CompleteFlowEnum.name.name: 'AuthFlow',
+        CompleteFlowEnum.description.name: 'Desc',
+        CompleteFlowEnum.stepsByIndex.name: <String, dynamic>{
+          '10': <String, dynamic>{
+            FlowStepEnum.indexNumber.name: 10,
+            FlowStepEnum.title.name: 'Authenticate',
+            FlowStepEnum.description.name: 'd',
+            FlowStepEnum.failureCode.name: 'AUTH_FAILED',
+            FlowStepEnum.nextOnSuccessIndex.name: -1,
+            FlowStepEnum.nextOnFailureIndex.name: -1,
+          },
+          '-1': <String, dynamic>{
+            // should be ignored by ModelCompleteFlow due to key < 0
+            FlowStepEnum.indexNumber.name: -1,
+            FlowStepEnum.title.name: 'END',
+            FlowStepEnum.description.name: 'd',
+            FlowStepEnum.failureCode.name: 'END',
+            FlowStepEnum.nextOnSuccessIndex.name: -1,
+            FlowStepEnum.nextOnFailureIndex.name: -1,
+          },
+        },
+      };
+
+      // Act
+      final ModelCompleteFlow flow = ModelCompleteFlow.fromJson(json);
+
+      // Assert
+      expect(flow.name, equals('AuthFlow'));
+      expect(flow.stepsByIndex.containsKey(10), isTrue);
+      expect(flow.stepsByIndex.containsKey(-1), isFalse);
+
+      // Deep immutability (map itself)
+      expect(
+        () => flow.stepsByIndex[99] = flow.stepsByIndex[10]!,
+        throwsUnsupportedError,
+      );
+    });
+
+    test(
+        'Given a flow When toJson and fromJson Then preserves equality (roundtrip)',
+        () {
+      // Arrange
+      final ModelCompleteFlow original = ModelCompleteFlow.immutable(
+        name: 'Flow',
+        description: 'Desc',
+        steps: <ModelFlowStep>[
+          ModelFlowStep.immutable(
+            index: 20,
+            title: 'B',
+            description: 'd',
+            failureCode: 'X',
+            nextOnSuccessIndex: -1,
+            nextOnFailureIndex: -1,
+            cost: const <String, double>{'latencyMs': 10},
+          ),
+          ModelFlowStep.immutable(
+            index: 10,
+            title: 'A',
+            description: 'd',
+            failureCode: 'X',
+            nextOnSuccessIndex: 20,
+            nextOnFailureIndex: -1,
+          ),
+        ],
+      );
+
+      // Act
+      final Map<String, dynamic> json = original.toJson();
+      final ModelCompleteFlow roundtrip = ModelCompleteFlow.fromJson(json);
+
+      // Assert
+      expect(roundtrip, equals(original));
+      expect(roundtrip.hashCode, equals(original.hashCode));
+    });
+
+    test(
+        'Given JSON with non-map stepsByIndex When parsing Then uses safe defaults',
+        () {
+      // Arrange
+      final Map<String, dynamic> json = <String, dynamic>{
+        CompleteFlowEnum.name.name: 'Flow',
+        CompleteFlowEnum.description.name: 'Desc',
+        CompleteFlowEnum.stepsByIndex.name: 'not a map',
+      };
+
+      // Act
+      final ModelCompleteFlow flow = ModelCompleteFlow.fromJson(json);
+
+      // Assert
+      expect(flow.name, equals('Flow'));
+      expect(flow.stepsByIndex, isEmpty);
+      expect(flow.entryIndex, equals(-1));
+    });
+  });
+
+  group('Views: stepsSorted / entryIndex / stepAt', () {
+    test(
+        'Given unsorted steps When reading stepsSorted Then returns them ordered by index',
+        () {
+      // Arrange
+      final ModelCompleteFlow flow = ModelCompleteFlow.immutable(
+        name: 'Flow',
+        description: 'Desc',
+        steps: <ModelFlowStep>[
+          ModelFlowStep.immutable(
+            index: 20,
+            title: 'B',
+            description: 'd',
+            failureCode: 'X',
+            nextOnSuccessIndex: -1,
+            nextOnFailureIndex: -1,
+          ),
+          ModelFlowStep.immutable(
+            index: 10,
+            title: 'A',
+            description: 'd',
+            failureCode: 'X',
+            nextOnSuccessIndex: -1,
+            nextOnFailureIndex: -1,
+          ),
+        ],
+      );
+
+      // Act
+      final List<ModelFlowStep> sorted = flow.stepsSorted;
+
+      // Assert
+      expect(
+        sorted.map((ModelFlowStep s) => s.index).toList(),
+        equals(<int>[10, 20]),
+      );
+      expect(() => sorted.add(sorted.first), throwsUnsupportedError);
+    });
+
+    test(
+        'Given non-empty flow When reading entryIndex Then returns smallest index',
+        () {
+      // Arrange
+      final ModelCompleteFlow flow = ModelCompleteFlow.immutable(
+        name: 'Flow',
+        description: 'Desc',
+        steps: <ModelFlowStep>[
+          ModelFlowStep.immutable(
+            index: 5,
+            title: 'A',
+            description: 'd',
+            failureCode: 'X',
+            nextOnSuccessIndex: -1,
+            nextOnFailureIndex: -1,
+          ),
+          ModelFlowStep.immutable(
+            index: 2,
+            title: 'B',
+            description: 'd',
+            failureCode: 'X',
+            nextOnSuccessIndex: -1,
+            nextOnFailureIndex: -1,
+          ),
+        ],
+      );
+
+      // Assert
+      expect(flow.entryIndex, equals(2));
+      expect(flow.stepAt(5)?.title, equals('A'));
+      expect(flow.stepAt(999), isNull);
+    });
+  });
+
+  group('Mutations: upsertStep / removeStepAt', () {
+    test(
+        'Given step with negative index When upserting Then returns same object',
+        () {
+      // Arrange
+      final ModelCompleteFlow flow = ModelCompleteFlow.immutable(
+        name: 'Flow',
+        description: 'Desc',
+      );
+
+      final ModelFlowStep end = ModelFlowStep.immutable(
+        index: -1,
+        title: 'END',
+        description: 'd',
+        failureCode: 'END',
+        nextOnSuccessIndex: -1,
+        nextOnFailureIndex: -1,
+      );
+
+      // Act
+      final ModelCompleteFlow result = flow.upsertStep(end);
+
+      // Assert
+      expect(identical(result, flow), isTrue);
+      expect(result.stepsByIndex, isEmpty);
+    });
+
+    test(
+        'Given empty flow When upserting valid step Then adds it and returns new object',
+        () {
+      // Arrange
+      final ModelCompleteFlow flow = ModelCompleteFlow.immutable(
+        name: 'Flow',
+        description: 'Desc',
+      );
+
+      final ModelFlowStep step = ModelFlowStep.immutable(
+        index: 10,
+        title: 'A',
+        description: 'd',
+        failureCode: 'X',
+        nextOnSuccessIndex: -1,
+        nextOnFailureIndex: -1,
+      );
+
+      // Act
+      final ModelCompleteFlow result = flow.upsertStep(step);
+
+      // Assert
+      expect(identical(result, flow), isFalse);
+      expect(result.stepsByIndex.containsKey(10), isTrue);
+      expect(result.stepsByIndex[10]?.title, equals('A'));
+    });
+
+    test(
+        'Given flow with same step When upserting equal step Then returns same object',
+        () {
+      // Arrange
+      final ModelFlowStep step = ModelFlowStep.immutable(
+        index: 10,
+        title: 'A',
+        description: 'd',
+        failureCode: 'X',
+        nextOnSuccessIndex: -1,
+        nextOnFailureIndex: -1,
+      );
+
+      final ModelCompleteFlow flow = ModelCompleteFlow.immutable(
+        name: 'Flow',
+        description: 'Desc',
+        steps: <ModelFlowStep>[step],
+      );
+
+      // Act
+      final ModelCompleteFlow result = flow.upsertStep(step);
+
+      // Assert
+      expect(identical(result, flow), isTrue);
+    });
+
+    test(
+        'Given flow missing index When removeStepAt called Then returns same object',
+        () {
+      // Arrange
+      final ModelCompleteFlow flow = ModelCompleteFlow.immutable(
+        name: 'Flow',
+        description: 'Desc',
+        steps: <ModelFlowStep>[
+          ModelFlowStep.immutable(
+            index: 1,
+            title: 'A',
+            description: 'd',
+            failureCode: 'X',
+            nextOnSuccessIndex: -1,
+            nextOnFailureIndex: -1,
+          ),
+        ],
+      );
+
+      // Act
+      final ModelCompleteFlow result = flow.removeStepAt(999);
+
+      // Assert
+      expect(identical(result, flow), isTrue);
+    });
+
+    test(
+        'Given flow with index When removeStepAt called Then removes and returns new object',
+        () {
+      // Arrange
+      final ModelCompleteFlow flow = ModelCompleteFlow.immutable(
+        name: 'Flow',
+        description: 'Desc',
+        steps: <ModelFlowStep>[
+          ModelFlowStep.immutable(
+            index: 1,
+            title: 'A',
+            description: 'd',
+            failureCode: 'X',
+            nextOnSuccessIndex: -1,
+            nextOnFailureIndex: -1,
+          ),
+        ],
+      );
+
+      // Act
+      final ModelCompleteFlow result = flow.removeStepAt(1);
+
+      // Assert
+      expect(identical(result, flow), isFalse);
+      expect(result.stepsByIndex.containsKey(1), isFalse);
+    });
+  });
+
+  group('ModelCompleteFlow.copyWith()', () {
+    test(
+        'Given flow When copyWith called with no args Then returns same object (identical)',
+        () {
+      // Arrange
+      final ModelCompleteFlow flow = ModelCompleteFlow.immutable(
+        name: 'Flow',
+        description: 'Desc',
+      );
+
+      // Act
+      final ModelCompleteFlow copied = flow.copyWith();
+
+      // Assert
+      expect(identical(copied, flow), isTrue);
+    });
+
+    test(
+        'Given flow When copyWith changes name Then returns new deeply immutable flow',
+        () {
+      // Arrange
+      final ModelCompleteFlow flow = ModelCompleteFlow.immutable(
+        name: 'Flow',
+        description: 'Desc',
+        steps: <ModelFlowStep>[
+          ModelFlowStep.immutable(
+            index: 1,
+            title: 'A',
+            description: 'd',
+            failureCode: 'X',
+            nextOnSuccessIndex: -1,
+            nextOnFailureIndex: -1,
+          ),
+        ],
+      );
+
+      // Act
+      final ModelCompleteFlow updated = flow.copyWith(name: 'NewName');
+
+      // Assert
+      expect(identical(updated, flow), isFalse);
+      expect(updated.name, equals('NewName'));
+      expect(updated.stepsByIndex.containsKey(1), isTrue);
+
+      // still unmodifiable
+      expect(() => updated.stepsByIndex.remove(1), throwsUnsupportedError);
+    });
+  });
+
+  group('HashCode contract', () {
+    test('Given two equal flows When comparing Then hashCode is equal', () {
+      // Arrange
+      final ModelCompleteFlow a = ModelCompleteFlow.immutable(
+        name: 'Flow',
+        description: 'Desc',
+        steps: <ModelFlowStep>[
+          ModelFlowStep.immutable(
+            index: 2,
+            title: 'B',
+            description: 'd',
+            failureCode: 'X',
+            nextOnSuccessIndex: -1,
+            nextOnFailureIndex: -1,
+          ),
+          ModelFlowStep.immutable(
+            index: 1,
+            title: 'A',
+            description: 'd',
+            failureCode: 'X',
+            nextOnSuccessIndex: 2,
+            nextOnFailureIndex: -1,
+          ),
+        ],
+      );
+
+      final ModelCompleteFlow b = ModelCompleteFlow.immutableFromMap(
+        name: 'Flow',
+        description: 'Desc',
+        stepsByIndex: <int, ModelFlowStep>{
+          1: ModelFlowStep.immutable(
+            index: 1,
+            title: 'A',
+            description: 'd',
+            failureCode: 'X',
+            nextOnSuccessIndex: 2,
+            nextOnFailureIndex: -1,
+          ),
+          2: ModelFlowStep.immutable(
+            index: 2,
+            title: 'B',
+            description: 'd',
+            failureCode: 'X',
+            nextOnSuccessIndex: -1,
+            nextOnFailureIndex: -1,
+          ),
+        },
+      );
+
+      // Assert
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+    });
+  });
+}

--- a/test/domain/either_flow/model_flow_step_test.dart
+++ b/test/domain/either_flow/model_flow_step_test.dart
@@ -1,0 +1,280 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jocaagura_domain/jocaagura_domain.dart';
+
+void main() {
+  group('ModelFlowStep.immutable()', () {
+    test(
+        'Given mutable inputs When building immutable Then instance is not affected by later mutations',
+        () {
+      // Arrange
+      final List<String> constraints = <String>['requiresInternet'];
+      final Map<String, double> cost = <String, double>{
+        'latencyMs': 250,
+        'networkKb': 12.5,
+      };
+
+      // Act
+      final ModelFlowStep step = ModelFlowStep.immutable(
+        index: 10,
+        title: 'Authenticate',
+        description: 'Runs auth use case',
+        failureCode: 'AUTH_FAILED',
+        nextOnSuccessIndex: 11,
+        nextOnFailureIndex: 99,
+        constraints: constraints,
+        cost: cost,
+      );
+
+      // Mutate originals after construction
+      constraints.add('role:admin');
+      cost['latencyMs'] = 999;
+
+      // Assert
+      expect(step.constraints, equals(<String>['requiresInternet']));
+      expect(step.cost['latencyMs'], equals(250));
+    });
+
+    test(
+        'Given immutable instance When mutating constraints/cost Then throws UnsupportedError',
+        () {
+      // Arrange
+      final ModelFlowStep step = ModelFlowStep.immutable(
+        index: 1,
+        title: 't',
+        description: 'd',
+        failureCode: 'X',
+        nextOnSuccessIndex: -1,
+        nextOnFailureIndex: -1,
+        constraints: const <String>['a'],
+        cost: const <String, double>{'latencyMs': 10},
+      );
+
+      // Assert
+      expect(() => step.constraints.add('b'), throwsUnsupportedError);
+      expect(() => step.cost['networkKb'] = 1.0, throwsUnsupportedError);
+    });
+
+    test(
+        'Given non-finite/negative costs When building immutable Then normalizes to 0.0',
+        () {
+      // Arrange
+      final Map<String, double> cost = <String, double>{
+        'nan': double.nan,
+        'inf': double.infinity,
+        'neg': -1,
+        'ok': 2.5,
+      };
+
+      // Act
+      final ModelFlowStep step = ModelFlowStep.immutable(
+        index: 1,
+        title: 't',
+        description: 'd',
+        failureCode: 'X',
+        nextOnSuccessIndex: 2,
+        nextOnFailureIndex: 3,
+        cost: cost,
+      );
+
+      // Assert
+      expect(step.cost['nan'], equals(0.0));
+      expect(step.cost['inf'], equals(0.0));
+      expect(step.cost['neg'], equals(0.0));
+      expect(step.cost['ok'], equals(2.5));
+    });
+  });
+
+  group('ModelFlowStep.fromJson()', () {
+    test(
+        'Given empty json When parsing Then uses safe defaults and returns deeply immutable instance',
+        () {
+      // Arrange
+      final Map<String, dynamic> json = <String, dynamic>{};
+
+      // Act
+      final ModelFlowStep step = ModelFlowStep.fromJson(json);
+
+      // Assert
+      expect(step.failureCode, equals(defaultModelFlowStepModel.failureCode));
+      expect(step.constraints, isEmpty);
+      expect(step.cost, isEmpty);
+
+      // Deep immutability expectations (requires fromJson to return ModelFlowStep.immutable)
+      expect(() => step.constraints.add('x'), throwsUnsupportedError);
+      expect(() => step.cost['k'] = 1.0, throwsUnsupportedError);
+    });
+
+    test(
+        'Given cost with dynamic values When parsing Then normalizes invalid to 0.0',
+        () {
+      // Arrange
+      final Map<String, dynamic> json = <String, dynamic>{
+        FlowStepEnum.cost.name: <String, dynamic>{
+          'latencyMs': '250',
+          'nan': double.nan,
+          'neg': -2,
+        },
+      };
+
+      // Act
+      final ModelFlowStep step = ModelFlowStep.fromJson(json);
+
+      // Assert
+      expect(step.cost['latencyMs'], equals(250.0));
+      expect(step.cost['nan'], equals(0.0));
+      expect(step.cost['neg'], equals(0.0));
+    });
+
+    test(
+        'Given instance When toJson/fromJson Then preserves equality (roundtrip)',
+        () {
+      // Arrange
+      final ModelFlowStep original = ModelFlowStep.immutable(
+        index: 10,
+        title: 'Authenticate',
+        description: 'Runs auth use case',
+        failureCode: 'AUTH_FAILED',
+        nextOnSuccessIndex: 11,
+        nextOnFailureIndex: 99,
+        constraints: const <String>['requiresInternet'],
+        cost: const <String, double>{'latencyMs': 250, 'networkKb': 12.5},
+      );
+
+      // Act
+      final Map<String, dynamic> json = original.toJson();
+      final ModelFlowStep roundtrip = ModelFlowStep.fromJson(json);
+
+      // Assert
+      expect(roundtrip, equals(original));
+    });
+  });
+
+  group('ModelFlowStep.copyWith()', () {
+    test(
+        'Given instance When copyWith called with no args Then returns same object (identical)',
+        () {
+      // Arrange
+      final ModelFlowStep step = ModelFlowStep.immutable(
+        index: 1,
+        title: 't',
+        description: 'd',
+        failureCode: 'X',
+        nextOnSuccessIndex: 2,
+        nextOnFailureIndex: 3,
+      );
+
+      // Act
+      final ModelFlowStep copied = step.copyWith();
+
+      // Assert
+      expect(identical(copied, step), isTrue);
+    });
+
+    test(
+        'Given instance When copyWith changes one field Then returns a new object with updated value',
+        () {
+      // Arrange
+      final ModelFlowStep step = ModelFlowStep.immutable(
+        index: 1,
+        title: 't',
+        description: 'd',
+        failureCode: 'X',
+        nextOnSuccessIndex: 2,
+        nextOnFailureIndex: 3,
+      );
+
+      // Act
+      final ModelFlowStep updated = step.copyWith(title: 'new');
+
+      // Assert
+      expect(identical(updated, step), isFalse);
+      expect(updated.title, equals('new'));
+      expect(updated.index, equals(step.index));
+    });
+  });
+
+  group('Equality & hashCode', () {
+    test('Given two equal instances When comparing Then hashCode is equal', () {
+      // Arrange
+      final ModelFlowStep a = ModelFlowStep.immutable(
+        index: 1,
+        title: 't',
+        description: 'd',
+        failureCode: 'X',
+        nextOnSuccessIndex: 2,
+        nextOnFailureIndex: 3,
+        constraints: const <String>['c1', 'c2'],
+        cost: const <String, double>{'latencyMs': 10, 'networkKb': 1.5},
+      );
+
+      final ModelFlowStep b = ModelFlowStep.immutable(
+        index: 1,
+        title: 't',
+        description: 'd',
+        failureCode: 'X',
+        nextOnSuccessIndex: 2,
+        nextOnFailureIndex: 3,
+        constraints: const <String>['c1', 'c2'],
+        cost: const <String, double>{'latencyMs': 10, 'networkKb': 1.5},
+      );
+
+      // Act + Assert
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+    });
+
+    test(
+        'Given same cost entries with different insertion order When comparing Then equals and same hashCode',
+        () {
+      // Arrange
+      final ModelFlowStep a = ModelFlowStep.immutable(
+        index: 1,
+        title: 't',
+        description: 'd',
+        failureCode: 'X',
+        nextOnSuccessIndex: 2,
+        nextOnFailureIndex: 3,
+        cost: const <String, double>{'aMs': 1, 'bKb': 2},
+      );
+
+      final ModelFlowStep b = ModelFlowStep.immutable(
+        index: 1,
+        title: 't',
+        description: 'd',
+        failureCode: 'X',
+        nextOnSuccessIndex: 2,
+        nextOnFailureIndex: 3,
+        cost: const <String, double>{
+          'bKb': 2,
+          'aMs': 1,
+        }, // different insertion order
+      );
+
+      // Assert
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+    });
+
+    test(
+        'Given a single instance When reading hashCode multiple times Then it is stable',
+        () {
+      // Arrange
+      final ModelFlowStep step = ModelFlowStep.immutable(
+        index: 7,
+        title: 't',
+        description: 'd',
+        failureCode: 'X',
+        nextOnSuccessIndex: 8,
+        nextOnFailureIndex: 9,
+        cost: const <String, double>{'latencyMs': 123},
+      );
+
+      // Act
+      final int h1 = step.hashCode;
+      final int h2 = step.hashCode;
+
+      // Assert
+      expect(h1, equals(h2));
+    });
+  });
+}


### PR DESCRIPTION
## [1.35.0] - 2025-12-18

### Added

* Added `ModelCompleteFlow`, a new immutable domain model to represent a complete deterministic diagram composed of multiple `ModelFlowStep` items.
* Added `CompleteFlowEnum` to guarantee stable JSON keys via `enum.name` for `ModelCompleteFlow`.
* Added `defaultModelCompleteFlow` as a safe fallback/testing instance.

### Features

* Implemented canonical **Map-based** storage and JSON contract: `stepsByIndex` (`Map<int, ModelFlowStep>`), serialized as a JSON map keyed by step index as **string** (e.g., `"10"`).
* Implemented deterministic, **roundtrip-safe** JSON serialization/deserialization:

    * Defensive parsing using `Utils.*FromDynamic`.
    * Stable emission order using `stepsSorted` (sorted by index).
    * Lenient `fromJson` that never throws and applies safe defaults.

### Immutability

* Ensured deep immutability:

    * `stepsByIndex` is stored as `Map<int, ModelFlowStep>.unmodifiable`.
    * Inserted/updated steps are normalized through `ModelCompleteFlow.asImmutableStep(...)` (internally leveraging `ModelFlowStep.immutable`).

### Helpers

* Added ergonomic helpers for diagram manipulation (immutable copy semantics):

    * `stepsSorted` for stable UI/export ordering.
    * `entryIndex` to determine the diagram entry point (smallest index, or `-1` if empty).
    * `stepAt(int index)` to retrieve a step by index.
    * `upsertStep(ModelFlowStep step)` to insert/update by `step.index`.
    * `removeStepAt(int index)` and `removeStep(ModelFlowStep step)` to delete steps.

### Behavior and Contracts

* Enforced END semantics:

    * Steps with `index < 0` (including `-1`) are ignored and not stored.
    * `index == -1` remains reserved exclusively as an END target for routing.

### Equality & Hashing

* Added value-based equality and hashing for `ModelCompleteFlow`:

    * `operator ==` compares `name`, `description`, and deep equality for `stepsByIndex` via `Utils.deepEqualsDynamic`.
    * `hashCode` uses `Object.hash(...)` plus `Utils.deepHash(stepsByIndex)`.

### Documentation

* Added comprehensive DartDoc to `ModelCompleteFlow` including usage guidance, immutability guarantees, JSON contract shape, and an executable `main()` example.

### Tests

* Added unit tests for `ModelCompleteFlow` covering:

    * Map-based JSON roundtrip (toJson/fromJson).
    * END semantics (`index < 0` ignored).
    * Deep immutability (unmodifiable collections).
    * `copyWith()` returning the same instance when no changes are requested.
    * `upsertStep`/`removeStepAt` behaviors (including no-op returning `this`).
    * `entryIndex`, `stepsSorted`, and `hashCode` consistency.
