### PR TITLE
Dev/create json schema documentation and validation contracts for jocaagura domain models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,50 @@
 This document follows the guidelines of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.38.2] - 2026-03-14
+
+### Added
+- **JSON Schema domain module**
+  - Nuevo módulo `lib/domain/json_schema/` para tratar contratos JSON Schema como dato dentro del dominio.
+  - Nuevo `ModelJsonSchemaDocument` como entidad principal para almacenar:
+    - identificador del documento
+    - identificador canónico del schema
+    - metadata funcional
+    - schema JSON completo como `Map<String, dynamic>`
+    - example canónico
+    - tags, timestamps y estado activo
+  - Nuevo `ModelJsonSchemaReference` para modelar relaciones explícitas entre contratos, pensado para composición, anidamiento y futuros grafos de dependencias.
+
+### Added
+- **Contratos del propio módulo**
+  - Nuevos schemas y examples en `doc/schemas/v1/` para:
+    - `model_json_schema_document.schema.json`
+    - `model_json_schema_reference.schema.json`
+  - Los examples asociados validan correctamente dentro del flujo local de `npm run validate:schemas`.
+
+### Tests
+- Nuevas pruebas unitarias para el módulo `json_schema` cubriendo:
+  - roundtrip `fromJson(toJson(model))`
+  - roundtrip `toJson(fromJson(jsonCanonico))`
+  - `copyWith`
+  - igualdad por valor
+
+### Changed
+- **Ajuste semántico de nombres en el contenedor de schemas**
+  - Se renombran campos del modelo y del contrato para evitar colisión conceptual con keywords nativas de JSON Schema:
+    - `title` -> `schemaTitle`
+    - `description` -> `schemaDescription`
+    - `ModelJsonSchemaReference.description` -> `referenceDescription`
+  - Esto aclara la diferencia entre:
+    - metadata del documento contenedor
+    - y contenido del schema almacenado dentro del campo `schema`
+
+### Docs
+- Se actualiza la documentación de schemas para dejar explícito que:
+  - el módulo `json_schema` almacena contratos completos como `Map<String, dynamic>`
+  - en esta fase no se modelan keyword por keyword las estructuras internas de JSON Schema
+  - `ModelJsonSchemaReference` existe para representar composición y anidamiento entre contratos
+
 ## [1.38.1] - 2026-01-19
 
 ### Added

--- a/doc/schemas/README.md
+++ b/doc/schemas/README.md
@@ -88,6 +88,7 @@ npm run validate:schemas
 - `AttributeModel.value` representa un valor JSON interoperable, no un tipo Dart.
 - `PersonModel.attributes` se representa como diccionario de atributos nombrados.
 - `ModelItem.attributes` se representa como arreglo ordenado de `AttributeModel`.
+- El módulo `json_schema` almacena contratos completos como `Map<String, dynamic>`, sin modelar keyword por keyword en Dart en esta fase.
 
 ## Brechas conocidas con la implementación Dart
 

--- a/doc/schemas/v1/README.md
+++ b/doc/schemas/v1/README.md
@@ -23,6 +23,8 @@ Esta carpeta contiene la primera version de contratos JSON canonicos para `jocaa
 - `medical_treatment_model.schema.json`
 - `model_config_http_request.schema.json`
 - `model_assessment.schema.json`
+- `model_json_schema_document.schema.json`
+- `model_json_schema_reference.schema.json`
 - `model_competency_standard.schema.json`
 - `model_graph.schema.json`
 - `model_graph_axis_spec.schema.json`
@@ -69,6 +71,7 @@ Esta carpeta contiene la primera version de contratos JSON canonicos para `jocaa
 - `treatment_plan_model.schema.json` referencia `medical_treatment_model.schema.json`
 - `medical_record_model.schema.json` referencia `person_model.schema.json`, `diagnosis_model.schema.json`, `dental_condition_model.schema.json`, `treatment_plan_model.schema.json`, `acceptance_clause_model.schema.json`, `address_model.schema.json`, `legal_id_model.schema.json`, `user_model.schema.json`, `appointment_model.schema.json`, `medication_model.schema.json` y `contact_model.schema.json`
 - `onboarding_state.schema.json` referencia `error_item_model.schema.json`
+- `model_json_schema_document.schema.json` almacena un JSON Schema completo como dato y no fija referencias cerradas dentro de `schema`
 - `model_competency_standard.schema.json` referencia `model_category.schema.json`
 - `model_learning_goal.schema.json` referencia `model_competency_standard.schema.json`
 - `model_performance_indicator.schema.json` referencia `model_learning_goal.schema.json`
@@ -141,6 +144,10 @@ Resultado esperado:
   - `DentalConditionModel.fromJson()` acepta strings y normaliza a entero.
 - `medical_record_model.schema.json`
   - el example se alinea deliberadamente con los contratos canónicos de `UserModel`, `AppointmentModel` y `ContactModel`, no con formas legacy que puedan existir en ejemplos Dart antiguos.
+- `model_json_schema_document.schema.json`
+  - almacena un JSON Schema completo como `Map<String, dynamic>`.
+  - usa `schemaTitle` y `schemaDescription` para evitar colisión semántica con las keywords nativas `title` y `description` del schema almacenado.
+  - en esta fase no se modelan internamente las keywords de JSON Schema como clases Dart separadas.
 
 ## Compatibilidad esperada
 

--- a/doc/schemas/v1/examples/model_json_schema_document.example.json
+++ b/doc/schemas/v1/examples/model_json_schema_document.example.json
@@ -1,0 +1,38 @@
+{
+  "id": "schema-doc-001",
+  "schemaId": "https://jocaagura.dev/schemas/jocaagura_domain/v1/address_model.schema.json",
+  "schemaTitle": "AddressModel",
+  "domainModel": "AddressModel",
+  "version": "v1",
+  "schemaDescription": "Canonical schema document for AddressModel.",
+  "schema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://jocaagura.dev/schemas/jocaagura_domain/v1/address_model.schema.json",
+    "title": "AddressModel",
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "id": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "id"
+    ],
+    "examples": [
+      {
+        "id": "addr_001"
+      }
+    ]
+  },
+  "example": {
+    "id": "addr_001"
+  },
+  "tags": [
+    "base",
+    "address"
+  ],
+  "createdAt": "2026-03-14T12:00:00.000Z",
+  "updatedAt": "2026-03-14T13:00:00.000Z",
+  "isActive": true
+}

--- a/doc/schemas/v1/examples/model_json_schema_reference.example.json
+++ b/doc/schemas/v1/examples/model_json_schema_reference.example.json
@@ -1,0 +1,8 @@
+{
+  "id": "schema-ref-001",
+  "sourceSchemaId": "https://jocaagura.dev/schemas/jocaagura_domain/v1/medical_record_model.schema.json",
+  "targetSchemaId": "https://jocaagura.dev/schemas/jocaagura_domain/v1/person_model.schema.json",
+  "referenceType": "ref",
+  "path": "/properties/patient",
+  "referenceDescription": "Medical record references the person contract for patient."
+}

--- a/doc/schemas/v1/model_json_schema_document.schema.json
+++ b/doc/schemas/v1/model_json_schema_document.schema.json
@@ -1,0 +1,120 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://jocaagura.dev/schemas/jocaagura_domain/v1/model_json_schema_document.schema.json",
+  "title": "ModelJsonSchemaDocument",
+  "description": "Canonical JSON contract for storing a complete JSON Schema document as domain data in jocaagura_domain.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "Internal identifier of the schema document record."
+    },
+    "schemaId": {
+      "type": "string",
+      "format": "uri",
+      "description": "Canonical identifier of the stored schema document, usually aligned with $id."
+    },
+    "schemaTitle": {
+      "type": "string",
+      "description": "Human-readable title of the stored schema contract."
+    },
+    "domainModel": {
+      "type": "string",
+      "description": "Domain model represented by the schema."
+    },
+    "version": {
+      "type": "string",
+      "description": "Version label of the contract line."
+    },
+    "schemaDescription": {
+      "type": "string",
+      "description": "Functional description of the stored schema contract."
+    },
+    "schema": {
+      "type": "object",
+      "description": "Complete JSON Schema document stored as JSON.",
+      "additionalProperties": true
+    },
+    "example": {
+      "type": "object",
+      "description": "Canonical example payload associated with the stored contract.",
+      "additionalProperties": true
+    },
+    "tags": {
+      "type": "array",
+      "description": "Tags used to classify the contract.",
+      "items": {
+        "type": "string"
+      }
+    },
+    "createdAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Creation timestamp as ISO-8601 string."
+    },
+    "updatedAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last update timestamp as ISO-8601 string."
+    },
+    "isActive": {
+      "type": "boolean",
+      "description": "Whether this schema document is active."
+    }
+  },
+  "required": [
+    "id",
+    "schemaId",
+    "schemaTitle",
+    "domainModel",
+    "version",
+    "schemaDescription",
+    "schema",
+    "example",
+    "tags",
+    "createdAt",
+    "updatedAt",
+    "isActive"
+  ],
+  "examples": [
+    {
+      "id": "schema-doc-001",
+      "schemaId": "https://jocaagura.dev/schemas/jocaagura_domain/v1/address_model.schema.json",
+      "schemaTitle": "AddressModel",
+      "domainModel": "AddressModel",
+      "version": "v1",
+      "schemaDescription": "Canonical schema document for AddressModel.",
+      "schema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": "https://jocaagura.dev/schemas/jocaagura_domain/v1/address_model.schema.json",
+        "title": "AddressModel",
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "examples": [
+          {
+            "id": "addr_001"
+          }
+        ]
+      },
+      "example": {
+        "id": "addr_001"
+      },
+      "tags": [
+        "base",
+        "address"
+      ],
+      "createdAt": "2026-03-14T12:00:00.000Z",
+      "updatedAt": "2026-03-14T13:00:00.000Z",
+      "isActive": true
+    }
+  ]
+}

--- a/doc/schemas/v1/model_json_schema_reference.schema.json
+++ b/doc/schemas/v1/model_json_schema_reference.schema.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://jocaagura.dev/schemas/jocaagura_domain/v1/model_json_schema_reference.schema.json",
+  "title": "ModelJsonSchemaReference",
+  "description": "Canonical JSON contract for an explicit dependency between two stored schema documents in jocaagura_domain.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "Internal identifier of the reference record."
+    },
+    "sourceSchemaId": {
+      "type": "string",
+      "format": "uri",
+      "description": "Canonical identifier of the source schema."
+    },
+    "targetSchemaId": {
+      "type": "string",
+      "format": "uri",
+      "description": "Canonical identifier of the target schema."
+    },
+    "referenceType": {
+      "type": "string",
+      "description": "Kind of relation between source and target schema.",
+      "enum": [
+        "ref",
+        "allOf",
+        "anyOf",
+        "oneOf",
+        "items",
+        "property"
+      ]
+    },
+    "path": {
+      "type": "string",
+      "description": "Path inside the source schema where the relationship appears."
+    },
+    "referenceDescription": {
+      "type": "string",
+      "description": "Functional explanation of the dependency."
+    }
+  },
+  "required": [
+    "id",
+    "sourceSchemaId",
+    "targetSchemaId",
+    "referenceType",
+    "path",
+    "referenceDescription"
+  ],
+  "examples": [
+    {
+      "id": "schema-ref-001",
+      "sourceSchemaId": "https://jocaagura.dev/schemas/jocaagura_domain/v1/medical_record_model.schema.json",
+      "targetSchemaId": "https://jocaagura.dev/schemas/jocaagura_domain/v1/person_model.schema.json",
+      "referenceType": "ref",
+      "path": "/properties/patient",
+      "referenceDescription": "Medical record references the person contract for patient."
+    }
+  ]
+}

--- a/lib/domain/json_schema/model_json_schema_document.dart
+++ b/lib/domain/json_schema/model_json_schema_document.dart
@@ -1,0 +1,211 @@
+part of 'package:jocaagura_domain/jocaagura_domain.dart';
+
+/// Stable JSON keys used by [ModelJsonSchemaDocument].
+enum ModelJsonSchemaDocumentEnum {
+  id,
+  schemaId,
+  schemaTitle,
+  domainModel,
+  version,
+  schemaDescription,
+  schema,
+  example,
+  tags,
+  createdAt,
+  updatedAt,
+  isActive,
+}
+
+/// Immutable domain document that stores a complete JSON Schema contract as data.
+///
+/// This model is the core of the `json_schema` module. It lets the domain
+/// transport, persist and version JSON Schema documents without coupling them to
+/// a specific implementation language.
+///
+/// Contract notes:
+/// - [schema] stores the full JSON Schema document as a JSON object.
+/// - [example] stores one canonical example payload associated with the schema.
+/// - [createdAt] and [updatedAt] are serialized as ISO-8601 strings.
+/// - [tags] is always normalized to a list of strings.
+class ModelJsonSchemaDocument extends Model {
+  const ModelJsonSchemaDocument({
+    required this.id,
+    required this.schemaId,
+    required this.schemaTitle,
+    required this.domainModel,
+    required this.version,
+    required this.schemaDescription,
+    required this.schema,
+    required this.example,
+    required this.tags,
+    required this.createdAt,
+    required this.updatedAt,
+    required this.isActive,
+  });
+
+  /// Rebuilds a [ModelJsonSchemaDocument] from JSON.
+  factory ModelJsonSchemaDocument.fromJson(Map<String, dynamic> json) {
+    return ModelJsonSchemaDocument(
+      id: Utils.getStringFromDynamic(
+        json[ModelJsonSchemaDocumentEnum.id.name],
+      ),
+      schemaId: Utils.getStringFromDynamic(
+        json[ModelJsonSchemaDocumentEnum.schemaId.name],
+      ),
+      schemaTitle: Utils.getStringFromDynamic(
+        json[ModelJsonSchemaDocumentEnum.schemaTitle.name],
+      ),
+      domainModel: Utils.getStringFromDynamic(
+        json[ModelJsonSchemaDocumentEnum.domainModel.name],
+      ),
+      version: Utils.getStringFromDynamic(
+        json[ModelJsonSchemaDocumentEnum.version.name],
+      ),
+      schemaDescription: Utils.getStringFromDynamic(
+        json[ModelJsonSchemaDocumentEnum.schemaDescription.name],
+      ),
+      schema: Utils.mapFromDynamic(
+        json[ModelJsonSchemaDocumentEnum.schema.name],
+      ),
+      example: Utils.mapFromDynamic(
+        json[ModelJsonSchemaDocumentEnum.example.name],
+      ),
+      tags: Utils.stringListFromDynamic(
+        json[ModelJsonSchemaDocumentEnum.tags.name],
+      ),
+      createdAt: DateUtils.dateTimeFromDynamic(
+        json[ModelJsonSchemaDocumentEnum.createdAt.name],
+      ),
+      updatedAt: DateUtils.dateTimeFromDynamic(
+        json[ModelJsonSchemaDocumentEnum.updatedAt.name],
+      ),
+      isActive: Utils.getBoolFromDynamic(
+        json[ModelJsonSchemaDocumentEnum.isActive.name],
+      ),
+    );
+  }
+
+  /// Internal identifier of the schema document record.
+  final String id;
+
+  /// Canonical schema identifier, usually aligned with `$id`.
+  final String schemaId;
+
+  /// Human-readable title of the contract.
+  final String schemaTitle;
+
+  /// Domain model described by the schema.
+  final String domainModel;
+
+  /// Version label of the contract line, e.g. `v1`.
+  final String version;
+
+  /// Functional description of the contract.
+  final String schemaDescription;
+
+  /// Full JSON Schema document stored as JSON object.
+  final Map<String, dynamic> schema;
+
+  /// Canonical example payload for the contract.
+  final Map<String, dynamic> example;
+
+  /// Classification tags for search and grouping.
+  final List<String> tags;
+
+  /// Creation timestamp.
+  final DateTime createdAt;
+
+  /// Last update timestamp.
+  final DateTime updatedAt;
+
+  /// Indicates whether the document is currently active.
+  final bool isActive;
+
+  @override
+  ModelJsonSchemaDocument copyWith({
+    String? id,
+    String? schemaId,
+    String? schemaTitle,
+    String? domainModel,
+    String? version,
+    String? schemaDescription,
+    Map<String, dynamic>? schema,
+    Map<String, dynamic>? example,
+    List<String>? tags,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+    bool? isActive,
+  }) {
+    return ModelJsonSchemaDocument(
+      id: id ?? this.id,
+      schemaId: schemaId ?? this.schemaId,
+      schemaTitle: schemaTitle ?? this.schemaTitle,
+      domainModel: domainModel ?? this.domainModel,
+      version: version ?? this.version,
+      schemaDescription: schemaDescription ?? this.schemaDescription,
+      schema: schema ?? this.schema,
+      example: example ?? this.example,
+      tags: tags ?? this.tags,
+      createdAt: createdAt ?? this.createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+      isActive: isActive ?? this.isActive,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      ModelJsonSchemaDocumentEnum.id.name: id,
+      ModelJsonSchemaDocumentEnum.schemaId.name: schemaId,
+      ModelJsonSchemaDocumentEnum.schemaTitle.name: schemaTitle,
+      ModelJsonSchemaDocumentEnum.domainModel.name: domainModel,
+      ModelJsonSchemaDocumentEnum.version.name: version,
+      ModelJsonSchemaDocumentEnum.schemaDescription.name: schemaDescription,
+      ModelJsonSchemaDocumentEnum.schema.name: schema,
+      ModelJsonSchemaDocumentEnum.example.name: example,
+      ModelJsonSchemaDocumentEnum.tags.name: tags,
+      ModelJsonSchemaDocumentEnum.createdAt.name:
+          DateUtils.dateTimeToString(createdAt),
+      ModelJsonSchemaDocumentEnum.updatedAt.name:
+          DateUtils.dateTimeToString(updatedAt),
+      ModelJsonSchemaDocumentEnum.isActive.name: isActive,
+    };
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ModelJsonSchemaDocument &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          schemaId == other.schemaId &&
+          schemaTitle == other.schemaTitle &&
+          domainModel == other.domainModel &&
+          version == other.version &&
+          schemaDescription == other.schemaDescription &&
+          Utils.deepEqualsDynamic(schema, other.schema) &&
+          Utils.deepEqualsDynamic(example, other.example) &&
+          Utils.deepEqualsDynamic(tags, other.tags) &&
+          createdAt == other.createdAt &&
+          updatedAt == other.updatedAt &&
+          isActive == other.isActive;
+
+  @override
+  int get hashCode => Object.hash(
+        id,
+        schemaId,
+        schemaTitle,
+        domainModel,
+        version,
+        schemaDescription,
+        Utils.deepHash(schema),
+        Utils.deepHash(example),
+        Utils.deepHash(tags),
+        createdAt,
+        updatedAt,
+        isActive,
+      );
+
+  @override
+  String toString() => 'ModelJsonSchemaDocument(${toJson()})';
+}

--- a/lib/domain/json_schema/model_json_schema_reference.dart
+++ b/lib/domain/json_schema/model_json_schema_reference.dart
@@ -1,0 +1,144 @@
+part of 'package:jocaagura_domain/jocaagura_domain.dart';
+
+/// Stable JSON keys used by [ModelJsonSchemaReference].
+enum ModelJsonSchemaReferenceEnum {
+  id,
+  sourceSchemaId,
+  targetSchemaId,
+  referenceType,
+  path,
+  referenceDescription,
+}
+
+/// Canonical reference kinds between schema documents.
+enum JsonSchemaReferenceTypeEnum {
+  ref,
+  allOf,
+  anyOf,
+  oneOf,
+  items,
+  property,
+}
+
+/// Immutable reference between two JSON Schema documents.
+///
+/// This model allows the domain to represent schema dependencies explicitly,
+/// which is useful for registries, dependency graphs and tooling.
+class ModelJsonSchemaReference extends Model {
+  const ModelJsonSchemaReference({
+    required this.id,
+    required this.sourceSchemaId,
+    required this.targetSchemaId,
+    required this.referenceType,
+    required this.path,
+    required this.referenceDescription,
+  });
+
+  /// Rebuilds a [ModelJsonSchemaReference] from JSON.
+  factory ModelJsonSchemaReference.fromJson(Map<String, dynamic> json) {
+    return ModelJsonSchemaReference(
+      id: Utils.getStringFromDynamic(
+        json[ModelJsonSchemaReferenceEnum.id.name],
+      ),
+      sourceSchemaId: Utils.getStringFromDynamic(
+        json[ModelJsonSchemaReferenceEnum.sourceSchemaId.name],
+      ),
+      targetSchemaId: Utils.getStringFromDynamic(
+        json[ModelJsonSchemaReferenceEnum.targetSchemaId.name],
+      ),
+      referenceType: _referenceTypeFromString(
+        Utils.getStringFromDynamic(
+          json[ModelJsonSchemaReferenceEnum.referenceType.name],
+        ),
+      ),
+      path: Utils.getStringFromDynamic(
+        json[ModelJsonSchemaReferenceEnum.path.name],
+      ),
+      referenceDescription: Utils.getStringFromDynamic(
+        json[ModelJsonSchemaReferenceEnum.referenceDescription.name],
+      ),
+    );
+  }
+
+  /// Internal identifier of the relationship record.
+  final String id;
+
+  /// Origin schema identifier.
+  final String sourceSchemaId;
+
+  /// Target schema identifier.
+  final String targetSchemaId;
+
+  /// Reference kind used in the relationship.
+  final JsonSchemaReferenceTypeEnum referenceType;
+
+  /// Path inside the source document where the relation appears.
+  final String path;
+
+  /// Functional explanation of the dependency.
+  final String referenceDescription;
+
+  @override
+  ModelJsonSchemaReference copyWith({
+    String? id,
+    String? sourceSchemaId,
+    String? targetSchemaId,
+    JsonSchemaReferenceTypeEnum? referenceType,
+    String? path,
+    String? referenceDescription,
+  }) {
+    return ModelJsonSchemaReference(
+      id: id ?? this.id,
+      sourceSchemaId: sourceSchemaId ?? this.sourceSchemaId,
+      targetSchemaId: targetSchemaId ?? this.targetSchemaId,
+      referenceType: referenceType ?? this.referenceType,
+      path: path ?? this.path,
+      referenceDescription: referenceDescription ?? this.referenceDescription,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      ModelJsonSchemaReferenceEnum.id.name: id,
+      ModelJsonSchemaReferenceEnum.sourceSchemaId.name: sourceSchemaId,
+      ModelJsonSchemaReferenceEnum.targetSchemaId.name: targetSchemaId,
+      ModelJsonSchemaReferenceEnum.referenceType.name: referenceType.name,
+      ModelJsonSchemaReferenceEnum.path.name: path,
+      ModelJsonSchemaReferenceEnum.referenceDescription.name:
+          referenceDescription,
+    };
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ModelJsonSchemaReference &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          sourceSchemaId == other.sourceSchemaId &&
+          targetSchemaId == other.targetSchemaId &&
+          referenceType == other.referenceType &&
+          path == other.path &&
+          referenceDescription == other.referenceDescription;
+
+  @override
+  int get hashCode => Object.hash(
+        id,
+        sourceSchemaId,
+        targetSchemaId,
+        referenceType,
+        path,
+        referenceDescription,
+      );
+
+  @override
+  String toString() => 'ModelJsonSchemaReference(${toJson()})';
+
+  static JsonSchemaReferenceTypeEnum _referenceTypeFromString(String? value) {
+    return JsonSchemaReferenceTypeEnum.values.firstWhere(
+      (JsonSchemaReferenceTypeEnum e) => e.name == value,
+      orElse: () => JsonSchemaReferenceTypeEnum.ref,
+    );
+  }
+}

--- a/lib/jocaagura_domain.dart
+++ b/lib/jocaagura_domain.dart
@@ -108,6 +108,8 @@ part 'domain/http/http_request_errors.dart';
 part 'domain/http/model_config_http_request.dart';
 part 'domain/http/request_context.dart';
 part 'domain/http/virtual_crud_service.dart';
+part 'domain/json_schema/model_json_schema_document.dart';
+part 'domain/json_schema/model_json_schema_reference.dart';
 part 'domain/legal_id_model.dart';
 part 'domain/medical/medical_diagnosis_tab_model.dart';
 part 'domain/medical/medication_model.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: jocaagura_domain
 description: "A package with domain models for all transversal applications"
 
-version: 1.38.1
+version: 1.38.2
 
 homepage: https://github.com/jocaagura/jocaagura_domain
 repository: https://github.com/jocaagura/jocaagura_domain

--- a/test/domain/json_schema_model_document_test.dart
+++ b/test/domain/json_schema_model_document_test.dart
@@ -1,0 +1,105 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jocaagura_domain/jocaagura_domain.dart';
+
+void main() {
+  group('ModelJsonSchemaDocument', () {
+    final DateTime createdAt = DateTime.utc(2026, 3, 14, 12);
+    final DateTime updatedAt = DateTime.utc(2026, 3, 14, 13);
+
+    final Map<String, dynamic> canonicalSchema = <String, dynamic>{
+      r'$schema': 'https://json-schema.org/draft/2020-12/schema',
+      r'$id':
+          'https://jocaagura.dev/schemas/jocaagura_domain/v1/address_model.schema.json',
+      'title': 'AddressModel',
+      'description': 'Canonical JSON contract for AddressModel.',
+      'type': 'object',
+      'additionalProperties': false,
+      'properties': <String, dynamic>{
+        'id': <String, dynamic>{'type': 'string'},
+      },
+      'required': <String>['id'],
+      'examples': <Map<String, dynamic>>[
+        <String, dynamic>{'id': 'addr_001'},
+      ],
+    };
+
+    final Map<String, dynamic> canonicalExample = <String, dynamic>{
+      'id': 'addr_001',
+    };
+
+    final ModelJsonSchemaDocument document = ModelJsonSchemaDocument(
+      id: 'schema-doc-001',
+      schemaId:
+          'https://jocaagura.dev/schemas/jocaagura_domain/v1/address_model.schema.json',
+      schemaTitle: 'AddressModel',
+      domainModel: 'AddressModel',
+      version: 'v1',
+      schemaDescription: 'Canonical schema document for AddressModel.',
+      schema: canonicalSchema,
+      example: canonicalExample,
+      tags: const <String>['base', 'address'],
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      isActive: true,
+    );
+
+    test(
+      'Given a canonical document When toJson and fromJson Then preserves the contract',
+      () {
+        final Map<String, dynamic> json = document.toJson();
+        final ModelJsonSchemaDocument roundtrip =
+            ModelJsonSchemaDocument.fromJson(json);
+
+        expect(roundtrip, document);
+        expect(roundtrip.toJson(), document.toJson());
+      },
+    );
+
+    test(
+      'Given canonical JSON When fromJson and toJson Then preserves JSON roundtrip',
+      () {
+        final Map<String, dynamic> json = <String, dynamic>{
+          ModelJsonSchemaDocumentEnum.id.name: 'schema-doc-001',
+          ModelJsonSchemaDocumentEnum.schemaId.name:
+              'https://jocaagura.dev/schemas/jocaagura_domain/v1/address_model.schema.json',
+          ModelJsonSchemaDocumentEnum.schemaTitle.name: 'AddressModel',
+          ModelJsonSchemaDocumentEnum.domainModel.name: 'AddressModel',
+          ModelJsonSchemaDocumentEnum.version.name: 'v1',
+          ModelJsonSchemaDocumentEnum.schemaDescription.name:
+              'Canonical schema document for AddressModel.',
+          ModelJsonSchemaDocumentEnum.schema.name: canonicalSchema,
+          ModelJsonSchemaDocumentEnum.example.name: canonicalExample,
+          ModelJsonSchemaDocumentEnum.tags.name: <String>['base', 'address'],
+          ModelJsonSchemaDocumentEnum.createdAt.name:
+              DateUtils.dateTimeToString(createdAt),
+          ModelJsonSchemaDocumentEnum.updatedAt.name:
+              DateUtils.dateTimeToString(updatedAt),
+          ModelJsonSchemaDocumentEnum.isActive.name: true,
+        };
+
+        final ModelJsonSchemaDocument parsed =
+            ModelJsonSchemaDocument.fromJson(json);
+
+        expect(parsed.toJson(), json);
+      },
+    );
+
+    test(
+      'Given a document When copyWith overrides selected fields Then returns updated immutable copy',
+      () {
+        final ModelJsonSchemaDocument copy = document.copyWith(
+          schemaTitle: 'Address Contract',
+          isActive: false,
+          tags: const <String>['base', 'contract'],
+        );
+
+        expect(copy.schemaTitle, 'Address Contract');
+        expect(copy.isActive, isFalse);
+        expect(copy.tags, const <String>['base', 'contract']);
+        expect(copy.schemaId, document.schemaId);
+        expect(copy.schema, document.schema);
+        expect(copy, isNot(document));
+      },
+    );
+  });
+}

--- a/test/domain/json_schema_model_reference_test.dart
+++ b/test/domain/json_schema_model_reference_test.dart
@@ -3,7 +3,7 @@ import 'package:jocaagura_domain/jocaagura_domain.dart';
 
 void main() {
   group('ModelJsonSchemaReference', () {
-    final ModelJsonSchemaReference reference = ModelJsonSchemaReference(
+    const ModelJsonSchemaReference reference = ModelJsonSchemaReference(
       id: 'schema-ref-001',
       sourceSchemaId:
           'https://jocaagura.dev/schemas/jocaagura_domain/v1/medical_record_model.schema.json',

--- a/test/domain/json_schema_model_reference_test.dart
+++ b/test/domain/json_schema_model_reference_test.dart
@@ -1,0 +1,68 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jocaagura_domain/jocaagura_domain.dart';
+
+void main() {
+  group('ModelJsonSchemaReference', () {
+    final ModelJsonSchemaReference reference = ModelJsonSchemaReference(
+      id: 'schema-ref-001',
+      sourceSchemaId:
+          'https://jocaagura.dev/schemas/jocaagura_domain/v1/medical_record_model.schema.json',
+      targetSchemaId:
+          'https://jocaagura.dev/schemas/jocaagura_domain/v1/person_model.schema.json',
+      referenceType: JsonSchemaReferenceTypeEnum.ref,
+      path: '/properties/patient',
+      referenceDescription:
+          'Medical record references the person contract for patient.',
+    );
+
+    test(
+      'Given a reference When toJson and fromJson Then preserves the dependency contract',
+      () {
+        final Map<String, dynamic> json = reference.toJson();
+        final ModelJsonSchemaReference roundtrip =
+            ModelJsonSchemaReference.fromJson(json);
+
+        expect(roundtrip, reference);
+        expect(roundtrip.toJson(), reference.toJson());
+      },
+    );
+
+    test(
+      'Given canonical JSON When fromJson and toJson Then preserves JSON roundtrip',
+      () {
+        final Map<String, dynamic> json = <String, dynamic>{
+          ModelJsonSchemaReferenceEnum.id.name: 'schema-ref-001',
+          ModelJsonSchemaReferenceEnum.sourceSchemaId.name:
+              'https://jocaagura.dev/schemas/jocaagura_domain/v1/medical_record_model.schema.json',
+          ModelJsonSchemaReferenceEnum.targetSchemaId.name:
+              'https://jocaagura.dev/schemas/jocaagura_domain/v1/person_model.schema.json',
+          ModelJsonSchemaReferenceEnum.referenceType.name: 'ref',
+          ModelJsonSchemaReferenceEnum.path.name: '/properties/patient',
+          ModelJsonSchemaReferenceEnum.referenceDescription.name:
+              'Medical record references the person contract for patient.',
+        };
+
+        final ModelJsonSchemaReference parsed =
+            ModelJsonSchemaReference.fromJson(json);
+
+        expect(parsed.toJson(), json);
+      },
+    );
+
+    test(
+      'Given a reference When copyWith overrides fields Then returns updated copy',
+      () {
+        final ModelJsonSchemaReference copy = reference.copyWith(
+          referenceType: JsonSchemaReferenceTypeEnum.property,
+          path: '/properties/patient/properties/id',
+        );
+
+        expect(copy.referenceType, JsonSchemaReferenceTypeEnum.property);
+        expect(copy.path, '/properties/patient/properties/id');
+        expect(copy.sourceSchemaId, reference.sourceSchemaId);
+        expect(copy.targetSchemaId, reference.targetSchemaId);
+        expect(copy, isNot(reference));
+      },
+    );
+  });
+}


### PR DESCRIPTION
- **JSON Schema domain module**
  - Nuevo módulo `lib/domain/json_schema/` para tratar contratos JSON Schema como dato dentro del dominio.
  - Nuevo `ModelJsonSchemaDocument` como entidad principal para almacenar:
    - identificador del documento
    - identificador canónico del schema
    - metadata funcional
    - schema JSON completo como `Map<String, dynamic>`
    - example canónico
    - tags, timestamps y estado activo
  - Nuevo `ModelJsonSchemaReference` para modelar relaciones explícitas entre contratos, pensado para composición, anidamiento y futuros grafos de dependencias.
