### PR TITLE
feat: add docs domain module and remove vulnerable schema tooling dep…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,45 @@
 This document follows the guidelines of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.38.7] - 2026-03-15
+
+### Added
+- **Docs domain module**
+  - Nuevo módulo `lib/domain/docs/` con:
+    - `ModelDocDocument`
+    - `ModelDocBlock`
+  - Los modelos materializan un dominio documental mínimo por bloques, agnóstico a renderer.
+  - `ModelDocDocument` organiza el contenido mediante `blocksByIndex`.
+  - `ModelDocBlock` define bloques `heading`, `paragraph` y `markdown`.
+- **Docs unit tests**
+  - Nuevas pruebas unitarias para:
+    - roundtrip `fromJson(toJson(model))`
+    - roundtrip `toJson(fromJson(jsonCanonico))`
+    - `copyWith`
+  - Cobertura inicial para:
+    - `doc_model_document_test.dart`
+    - `doc_model_block_test.dart`
+- **Docs JSON contracts**
+  - Nuevos schemas y examples canónicos en `doc/schemas/v1/` para:
+    - `model_doc_document.schema.json`
+    - `model_doc_block.schema.json`
+  - Se formaliza:
+    - `title` fuera del cuerpo del documento
+    - `blocksByIndex` como mapa indexado para preservar intención y orden
+    - `content` siempre como `string`
+    - `level` opcional solo para bloques `heading`
+
+### Changed
+- **Docs documentation**
+  - Se actualizan `doc/schemas/README.md` y `doc/schemas/v1/README.md` para reflejar:
+    - la semántica de `blocksByIndex`
+    - el alcance reducido de la fase
+    - la separación entre contrato documental y representación visual
+- **Schema validation tooling**
+  - Se reemplaza `ajv-cli` por un script propio basado en `ajv` y `ajv-formats`.
+  - Se elimina la cadena transitiva que incorporaba `fast-json-patch` en `package-lock.json`.
+  - El flujo `npm run validate:schemas` se mantiene operativo con el nuevo validador.
+
 ## [1.38.6] - 2026-03-15
 
 ### Added

--- a/doc/schemas/README.md
+++ b/doc/schemas/README.md
@@ -92,6 +92,8 @@ npm run validate:schemas
 - El dominio documental tipo Drive usa `ModelDriveItem` como payload base real y consumible.
 - En contratos Drive, `kind` y `mimeType` no son equivalentes: `kind` clasifica la naturaleza del recurso y `mimeType` describe su tipo interoperable de contenido o contenedor.
 - En contratos Drive, `path` representa una ruta canónica absoluta del árbol lógico y siempre usa `/` como separador.
+- El dominio documental tipo Docs usa `blocksByIndex` para preservar orden lógico de bloques sin depender de arrays.
+- En contratos Docs, `title` vive fuera del cuerpo y `content` siempre se serializa como `string`.
 - El dominio tabular tipo Sheets representa filas como `idRow + data`, donde `data` es un objeto JSON gobernado por columnas declaradas en la tabla.
 - En contratos tabulares tipo Sheets, la PK efectiva siempre se serializa como `String`, incluso cuando es autogenerada.
 

--- a/doc/schemas/v1/README.md
+++ b/doc/schemas/v1/README.md
@@ -24,6 +24,8 @@ Esta carpeta contiene la primera version de contratos JSON canonicos para `jocaa
 - `model_drive_file.schema.json`
 - `model_drive_folder.schema.json`
 - `model_drive_item.schema.json`
+- `model_doc_block.schema.json`
+- `model_doc_document.schema.json`
 - `model_config_http_request.schema.json`
 - `model_assessment.schema.json`
 - `model_json_schema_document.schema.json`
@@ -70,6 +72,7 @@ Esta carpeta contiene la primera version de contratos JSON canonicos para `jocaa
 ## Dependencias entre schemas
 
 - `model_drive_file.schema.json`, `model_drive_folder.schema.json` y `model_drive_item.schema.json` forman una familia contractual alineada, pero en `v1` se mantienen como contratos completos independientes para preservar validación simple con `additionalProperties: false`
+- `model_doc_document.schema.json` referencia `model_doc_block.schema.json`
 - `model_sheet_book.schema.json` referencia `model_sheet_table.schema.json`
 - `model_sheet_table.schema.json` referencia `model_sheet_column.schema.json`
 - `store_model.schema.json` referencia `address_model.schema.json`
@@ -132,6 +135,9 @@ Resultado esperado:
 - En contratos Drive, `kind` y `mimeType` son complementarios y no equivalentes
 - En contratos Drive, `path` debe ser absoluto, iniciar con `/` y representar una ruta lógica, no una ruta física del sistema operativo
 - En contratos Drive, la raíz documental se representa con `parentId: null`
+- En contratos Docs, `ModelDocDocument` organiza el contenido mediante `blocksByIndex`
+- En contratos Docs, `ModelDocBlock.kind` se limita a `heading`, `paragraph` y `markdown`
+- En contratos Docs, `ModelDocBlock.level` solo aplica a encabezados
 - En contratos Sheets, `ModelSheetRow` representa un registro persistible mediante `idRow` y `data`
 - En contratos Sheets, `idRow` es la PK efectiva y siempre se serializa como `string`
 - En contratos Sheets, `data` es un objeto JSON gobernado por los nombres únicos declarados en `ModelSheetColumn`
@@ -148,6 +154,7 @@ Resultado esperado:
 - Cuando un modelo reutiliza otro contrato ya definido, debe hacerlo mediante `$ref` y no duplicando shape.
 - Los examples deben ser internamente consistentes con el resto de contratos reutilizados.
 - En la familia Drive, `mimeType` canónico de carpeta es `application/vnd.jocaagura.folder`.
+- En la familia Docs, el markdown libre se limita a bloques `markdown` y no se modela rich text inline.
 - En la familia Sheets no se modelan labels visibles, fórmulas, orden visual, foreign keys ni versionado estructural.
 
 ## Brechas conocidas entre contrato y Dart actual
@@ -174,6 +181,9 @@ Resultado esperado:
 - `model_sheet_book.schema.json`, `model_sheet_table.schema.json`, `model_sheet_column.schema.json` y `model_sheet_row.schema.json`
   - formalizan el dominio tabular mínimo para persistencia tipo Sheets.
   - la validación fuerte de qué claves entran en `data` se gobierna por las columnas de la tabla, no por un schema dinámico generado en esta fase.
+- `model_doc_document.schema.json` y `model_doc_block.schema.json`
+  - formalizan el dominio mínimo de documentos por bloques.
+  - la representación visual final queda deliberadamente fuera del contrato y se delega al implementador.
 
 ## Compatibilidad esperada
 

--- a/doc/schemas/v1/examples/model_doc_block.example.json
+++ b/doc/schemas/v1/examples/model_doc_block.example.json
@@ -1,0 +1,5 @@
+{
+  "kind": "heading",
+  "content": "Bienvenido",
+  "level": 1
+}

--- a/doc/schemas/v1/examples/model_doc_document.example.json
+++ b/doc/schemas/v1/examples/model_doc_document.example.json
@@ -1,0 +1,19 @@
+{
+  "id": "doc_welcome",
+  "title": "Bienvenido",
+  "blocksByIndex": {
+    "0": {
+      "kind": "heading",
+      "content": "Bienvenido",
+      "level": 1
+    },
+    "1": {
+      "kind": "paragraph",
+      "content": "Este documento introduce la plataforma."
+    },
+    "2": {
+      "kind": "markdown",
+      "content": "- item 1\n- item 2"
+    }
+  }
+}

--- a/doc/schemas/v1/model_doc_block.schema.json
+++ b/doc/schemas/v1/model_doc_block.schema.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://jocaagura.dev/schemas/jocaagura_domain/v1/model_doc_block.schema.json",
+  "title": "ModelDocBlock",
+  "description": "Canonical JSON contract for a block-based document fragment in jocaagura_domain.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "kind": {
+      "type": "string",
+      "enum": [
+        "heading",
+        "paragraph",
+        "markdown"
+      ],
+      "description": "Logical kind of the block."
+    },
+    "content": {
+      "type": "string",
+      "description": "Textual content of the block. Markdown syntax is only expected when kind is markdown."
+    },
+    "level": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 6,
+      "description": "Heading level used only when kind is heading."
+    }
+  },
+  "required": [
+    "kind",
+    "content"
+  ],
+  "examples": [
+    {
+      "kind": "heading",
+      "content": "Bienvenido",
+      "level": 1
+    }
+  ]
+}

--- a/doc/schemas/v1/model_doc_document.schema.json
+++ b/doc/schemas/v1/model_doc_document.schema.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://jocaagura.dev/schemas/jocaagura_domain/v1/model_doc_document.schema.json",
+  "title": "ModelDocDocument",
+  "description": "Canonical JSON contract for a block-based document in jocaagura_domain.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "Unique identifier of the document."
+    },
+    "title": {
+      "type": "string",
+      "description": "Document title outside the content blocks."
+    },
+    "blocksByIndex": {
+      "type": "object",
+      "description": "Dictionary of blocks keyed by logical index serialized as JSON string keys.",
+      "propertyNames": {
+        "pattern": "^[0-9]+$"
+      },
+      "additionalProperties": {
+        "$ref": "./model_doc_block.schema.json"
+      }
+    }
+  },
+  "required": [
+    "id",
+    "title",
+    "blocksByIndex"
+  ],
+  "examples": [
+    {
+      "id": "doc_welcome",
+      "title": "Bienvenido",
+      "blocksByIndex": {
+        "0": {
+          "kind": "heading",
+          "content": "Bienvenido",
+          "level": 1
+        },
+        "1": {
+          "kind": "paragraph",
+          "content": "Este documento introduce la plataforma."
+        },
+        "2": {
+          "kind": "markdown",
+          "content": "- item 1\n- item 2"
+        }
+      }
+    }
+  ]
+}

--- a/lib/domain/docs/model_doc_block.dart
+++ b/lib/domain/docs/model_doc_block.dart
@@ -1,0 +1,84 @@
+part of 'package:jocaagura_domain/jocaagura_domain.dart';
+
+/// Stable JSON keys used by [ModelDocBlock].
+enum ModelDocBlockEnum {
+  kind,
+  content,
+  level,
+}
+
+/// Canonical block kinds supported by the docs module.
+enum ModelDocBlockKindEnum {
+  heading,
+  paragraph,
+  markdown,
+}
+
+/// Minimal block-based content unit for portable docs.
+class ModelDocBlock extends Model {
+  const ModelDocBlock({
+    required this.kind,
+    required this.content,
+    this.level,
+  });
+
+  factory ModelDocBlock.fromJson(Map<String, dynamic> json) {
+    return ModelDocBlock(
+      kind: Utils.enumFromJson<ModelDocBlockKindEnum>(
+        ModelDocBlockKindEnum.values,
+        Utils.getStringFromDynamic(json[ModelDocBlockEnum.kind.name]),
+        ModelDocBlockKindEnum.paragraph,
+      ),
+      content: Utils.getStringFromDynamic(json[ModelDocBlockEnum.content.name]),
+      level: json.containsKey(ModelDocBlockEnum.level.name)
+          ? Utils.getIntegerFromDynamic(json[ModelDocBlockEnum.level.name])
+          : null,
+    );
+  }
+
+  final ModelDocBlockKindEnum kind;
+  final String content;
+  final int? level;
+
+  @override
+  ModelDocBlock copyWith({
+    ModelDocBlockKindEnum? kind,
+    String? content,
+    Object? level = _docUnset,
+  }) {
+    return ModelDocBlock(
+      kind: kind ?? this.kind,
+      content: content ?? this.content,
+      level: identical(level, _docUnset) ? this.level : level as int?,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> json = <String, dynamic>{
+      ModelDocBlockEnum.kind.name: kind.name,
+      ModelDocBlockEnum.content.name: content,
+    };
+    if (level != null) {
+      json[ModelDocBlockEnum.level.name] = level;
+    }
+    return json;
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ModelDocBlock &&
+          runtimeType == other.runtimeType &&
+          kind == other.kind &&
+          content == other.content &&
+          level == other.level;
+
+  @override
+  int get hashCode => Object.hash(kind, content, level);
+
+  @override
+  String toString() => 'ModelDocBlock(${toJson()})';
+}
+
+const Object _docUnset = Object();

--- a/lib/domain/docs/model_doc_document.dart
+++ b/lib/domain/docs/model_doc_document.dart
@@ -1,0 +1,91 @@
+part of 'package:jocaagura_domain/jocaagura_domain.dart';
+
+/// Stable JSON keys used by [ModelDocDocument].
+enum ModelDocDocumentEnum {
+  id,
+  title,
+  blocksByIndex,
+}
+
+/// Portable document composed of indexed blocks.
+class ModelDocDocument extends Model {
+  const ModelDocDocument({
+    required this.id,
+    required this.title,
+    required this.blocksByIndex,
+  });
+
+  factory ModelDocDocument.fromJson(Map<String, dynamic> json) {
+    final Map<int, ModelDocBlock> tmp = <int, ModelDocBlock>{};
+    final dynamic rawBlocks = json[ModelDocDocumentEnum.blocksByIndex.name];
+
+    if (rawBlocks is Map) {
+      for (final MapEntry<dynamic, dynamic> entry in rawBlocks.entries) {
+        final int indexKey = Utils.getIntegerFromDynamic(entry.key);
+        if (indexKey < 0) {
+          continue;
+        }
+        final Map<String, dynamic> blockJson =
+            Utils.mapFromDynamic(entry.value);
+        tmp[indexKey] = ModelDocBlock.fromJson(blockJson);
+      }
+    }
+
+    return ModelDocDocument(
+      id: Utils.getStringFromDynamic(json[ModelDocDocumentEnum.id.name]),
+      title: Utils.getStringFromDynamic(json[ModelDocDocumentEnum.title.name]),
+      blocksByIndex: Map<int, ModelDocBlock>.unmodifiable(tmp),
+    );
+  }
+
+  final String id;
+  final String title;
+  final Map<int, ModelDocBlock> blocksByIndex;
+
+  @override
+  ModelDocDocument copyWith({
+    String? id,
+    String? title,
+    Map<int, ModelDocBlock>? blocksByIndex,
+  }) {
+    return ModelDocDocument(
+      id: id ?? this.id,
+      title: title ?? this.title,
+      blocksByIndex: blocksByIndex ?? this.blocksByIndex,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    final List<int> keys = blocksByIndex.keys.toList(growable: false)..sort();
+    final Map<String, dynamic> byIndex = <String, dynamic>{};
+
+    for (final int key in keys) {
+      final ModelDocBlock? block = blocksByIndex[key];
+      if (block != null) {
+        byIndex[key.toString()] = block.toJson();
+      }
+    }
+
+    return <String, dynamic>{
+      ModelDocDocumentEnum.id.name: id,
+      ModelDocDocumentEnum.title.name: title,
+      ModelDocDocumentEnum.blocksByIndex.name: byIndex,
+    };
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ModelDocDocument &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          title == other.title &&
+          Utils.deepEqualsDynamic(blocksByIndex, other.blocksByIndex);
+
+  @override
+  int get hashCode => Object.hash(id, title, Utils.deepHash(blocksByIndex));
+
+  @override
+  String toString() => 'ModelDocDocument(${toJson()})';
+}

--- a/lib/jocaagura_domain.dart
+++ b/lib/jocaagura_domain.dart
@@ -72,6 +72,8 @@ part 'domain/dentist_app/diagnosis_model.dart';
 part 'domain/dentist_app/medical_record_model.dart';
 part 'domain/dentist_app/medical_treatment_model.dart';
 part 'domain/dentist_app/treatment_plan_model.dart';
+part 'domain/docs/model_doc_block.dart';
+part 'domain/docs/model_doc_document.dart';
 part 'domain/drive/model_drive_file.dart';
 part 'domain/drive/model_drive_folder.dart';
 part 'domain/drive/model_drive_item.dart';

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "jocaagura-domain-schema-tools",
       "version": "1.0.0",
       "devDependencies": {
-        "ajv-cli": "^5.0.0",
+        "ajv": "^8.18.0",
         "ajv-formats": "^3.0.1"
       }
     },
@@ -29,33 +29,6 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/ajv-cli": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ajv-cli/-/ajv-cli-5.0.0.tgz",
-      "integrity": "sha512-LY4m6dUv44HTyhV+u2z5uX4EhPYTM38Iv1jdgDJJJCyOOuqB8KtZEGjPZ2T+sh5ZIJrXUfgErYx/j3gLd3+PlQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^8.0.0",
-        "fast-json-patch": "^2.0.0",
-        "glob": "^7.1.0",
-        "js-yaml": "^3.14.0",
-        "json-schema-migrate": "^2.0.0",
-        "json5": "^2.1.3",
-        "minimist": "^1.2.0"
-      },
-      "bin": {
-        "ajv": "dist/index.js"
-      },
-      "peerDependencies": {
-        "ts-node": ">=9.0.0"
-      },
-      "peerDependenciesMeta": {
-        "ts-node": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/ajv-formats": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
@@ -74,79 +47,10 @@
         }
       }
     },
-    "node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/fast-json-patch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-2.2.1.tgz",
-      "integrity": "sha512-4j5uBaTnsYAV5ebkidvxiLUYOwjQ+JSFljeqfTxCrH9bDmlCQaOJFS84oDJ2rAXZq2yskmk3ORfoP9DCwqFNig==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/fast-json-patch/node_modules/fast-deep-equal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==",
       "dev": true,
       "license": "MIT"
     },
@@ -167,140 +71,12 @@
       ],
       "license": "BSD-3-Clause"
     },
-    "node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
-    "node_modules/inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/json-schema-migrate": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-migrate/-/json-schema-migrate-2.0.0.tgz",
-      "integrity": "sha512-r38SVTtojDRp4eD6WsCqiE0eNDt4v1WalBXb9cyZYw9ai5cGtBwzRNWjHzJl38w6TxFkXAIA7h+fyX3tnrAFhQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^8.0.0"
-      }
-    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/json5": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "json5": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "wrappy": "1"
-      }
-    },
-    "node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",
@@ -311,20 +87,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
-      "license": "ISC"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "validate:schemas": "powershell -ExecutionPolicy Bypass -File tools/validate-schemas.ps1"
   },
   "devDependencies": {
-    "ajv-cli": "^5.0.0",
+    "ajv": "^8.18.0",
     "ajv-formats": "^3.0.1"
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: jocaagura_domain
 description: "A package with domain models for all transversal applications"
 
-version: 1.38.6
+version: 1.38.7
 
 homepage: https://github.com/jocaagura/jocaagura_domain
 repository: https://github.com/jocaagura/jocaagura_domain

--- a/test/domain/doc_model_block_test.dart
+++ b/test/domain/doc_model_block_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jocaagura_domain/jocaagura_domain.dart';
+
+void main() {
+  group('ModelDocBlock', () {
+    const ModelDocBlock block = ModelDocBlock(
+      kind: ModelDocBlockKindEnum.heading,
+      content: 'Bienvenido',
+      level: 1,
+    );
+
+    test(
+      'Given a canonical block When toJson and fromJson Then preserves the contract',
+      () {
+        final Map<String, dynamic> json = block.toJson();
+        final ModelDocBlock roundtrip = ModelDocBlock.fromJson(json);
+
+        expect(roundtrip, block);
+        expect(roundtrip.toJson(), block.toJson());
+      },
+    );
+
+    test(
+      'Given canonical JSON When fromJson and toJson Then preserves JSON roundtrip',
+      () {
+        final Map<String, dynamic> json = <String, dynamic>{
+          ModelDocBlockEnum.kind.name: 'heading',
+          ModelDocBlockEnum.content.name: 'Bienvenido',
+          ModelDocBlockEnum.level.name: 1,
+        };
+
+        final ModelDocBlock parsed = ModelDocBlock.fromJson(json);
+
+        expect(parsed.toJson(), json);
+      },
+    );
+
+    test(
+      'Given a block When copyWith overrides fields Then returns updated copy',
+      () {
+        final ModelDocBlock copy = block.copyWith(
+          kind: ModelDocBlockKindEnum.markdown,
+          content: '- item 1\n- item 2',
+          level: null,
+        );
+
+        expect(copy.kind, ModelDocBlockKindEnum.markdown);
+        expect(copy.content, '- item 1\n- item 2');
+        expect(copy.level, isNull);
+        expect(copy, isNot(block));
+      },
+    );
+  });
+}

--- a/test/domain/doc_model_document_test.dart
+++ b/test/domain/doc_model_document_test.dart
@@ -1,0 +1,88 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jocaagura_domain/jocaagura_domain.dart';
+
+void main() {
+  group('ModelDocDocument', () {
+    const ModelDocDocument document = ModelDocDocument(
+      id: 'doc_welcome',
+      title: 'Bienvenido',
+      blocksByIndex: <int, ModelDocBlock>{
+        0: ModelDocBlock(
+          kind: ModelDocBlockKindEnum.heading,
+          content: 'Bienvenido',
+          level: 1,
+        ),
+        1: ModelDocBlock(
+          kind: ModelDocBlockKindEnum.paragraph,
+          content: 'Este documento introduce la plataforma.',
+        ),
+        2: ModelDocBlock(
+          kind: ModelDocBlockKindEnum.markdown,
+          content: '- item 1\n- item 2',
+        ),
+      },
+    );
+
+    test(
+      'Given a canonical document When toJson and fromJson Then preserves the contract',
+      () {
+        final Map<String, dynamic> json = document.toJson();
+        final ModelDocDocument roundtrip = ModelDocDocument.fromJson(json);
+
+        expect(roundtrip, document);
+        expect(roundtrip.toJson(), document.toJson());
+      },
+    );
+
+    test(
+      'Given canonical JSON When fromJson and toJson Then preserves JSON roundtrip',
+      () {
+        final Map<String, dynamic> json = <String, dynamic>{
+          ModelDocDocumentEnum.id.name: 'doc_welcome',
+          ModelDocDocumentEnum.title.name: 'Bienvenido',
+          ModelDocDocumentEnum.blocksByIndex.name: <String, dynamic>{
+            '0': <String, dynamic>{
+              ModelDocBlockEnum.kind.name: 'heading',
+              ModelDocBlockEnum.content.name: 'Bienvenido',
+              ModelDocBlockEnum.level.name: 1,
+            },
+            '1': <String, dynamic>{
+              ModelDocBlockEnum.kind.name: 'paragraph',
+              ModelDocBlockEnum.content.name:
+                  'Este documento introduce la plataforma.',
+            },
+            '2': <String, dynamic>{
+              ModelDocBlockEnum.kind.name: 'markdown',
+              ModelDocBlockEnum.content.name: '- item 1\n- item 2',
+            },
+          },
+        };
+
+        final ModelDocDocument parsed = ModelDocDocument.fromJson(json);
+
+        expect(parsed.toJson(), json);
+      },
+    );
+
+    test(
+      'Given a document When copyWith overrides fields Then returns updated copy',
+      () {
+        final ModelDocDocument copy = document.copyWith(
+          title: 'Bienvenida',
+          blocksByIndex: <int, ModelDocBlock>{
+            0: const ModelDocBlock(
+              kind: ModelDocBlockKindEnum.heading,
+              content: 'Bienvenida',
+              level: 1,
+            ),
+          },
+        );
+
+        expect(copy.title, 'Bienvenida');
+        expect(copy.blocksByIndex.length, 1);
+        expect(copy.blocksByIndex[0]?.content, 'Bienvenida');
+        expect(copy, isNot(document));
+      },
+    );
+  });
+}

--- a/tools/validate-schemas.mjs
+++ b/tools/validate-schemas.mjs
@@ -1,0 +1,68 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import Ajv2020 from 'ajv/dist/2020.js';
+import addFormats from 'ajv-formats';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '..');
+const schemaDir = path.join(repoRoot, 'doc', 'schemas', 'v1');
+const examplesDir = path.join(schemaDir, 'examples');
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function getSchemaBaseName(schemaFileName) {
+  return schemaFileName.replace(/\.schema\.json$/i, '');
+}
+
+const ajv = new Ajv2020({
+  strict: false,
+  allErrors: true,
+  validateFormats: true,
+});
+addFormats(ajv);
+
+const schemaFiles = fs
+  .readdirSync(schemaDir, { withFileTypes: true })
+  .filter((entry) => entry.isFile() && entry.name.endsWith('.schema.json'))
+  .map((entry) => entry.name)
+  .sort();
+
+for (const schemaFile of schemaFiles) {
+  const schemaPath = path.join(schemaDir, schemaFile);
+  const schema = readJson(schemaPath);
+  ajv.addSchema(schema, schema.$id ?? schemaPath);
+}
+
+for (const schemaFile of schemaFiles) {
+  const schemaPath = path.join(schemaDir, schemaFile);
+  const schema = readJson(schemaPath);
+  const validate =
+    (schema.$id && ajv.getSchema(schema.$id)) ||
+    ajv.getSchema(schemaPath) ||
+    ajv.compile(schema);
+
+  const examplePath = path.join(
+    examplesDir,
+    `${getSchemaBaseName(schemaFile)}.example.json`,
+  );
+
+  if (!fs.existsSync(examplePath)) {
+    throw new Error(`Example file not found for schema ${schemaFile}: ${examplePath}`);
+  }
+
+  const example = readJson(examplePath);
+  const valid = validate(example);
+  if (!valid) {
+    throw new Error(
+      `Example validation failed for ${examplePath}: ${ajv.errorsText(validate.errors, {
+        separator: '\n',
+      })}`,
+    );
+  }
+}
+
+console.log('AJV validation completed successfully.');

--- a/tools/validate-schemas.ps1
+++ b/tools/validate-schemas.ps1
@@ -4,7 +4,7 @@ $repoRoot = Split-Path -Parent $PSScriptRoot
 $schemaDir = Join-Path $repoRoot 'doc\schemas\v1'
 $examplesDir = Join-Path $schemaDir 'examples'
 $jqPath = Join-Path $repoRoot 'tools\jq\jq.exe'
-$ajvPath = Join-Path $repoRoot 'node_modules\.bin\ajv.cmd'
+$ajvScriptPath = Join-Path $repoRoot 'tools\validate-schemas.mjs'
 if (-not (Test-Path $schemaDir)) {
   throw "Schema directory not found: $schemaDir"
 }
@@ -17,8 +17,8 @@ if (-not (Test-Path $jqPath)) {
   throw "jq not found at $jqPath"
 }
 
-if (-not (Test-Path $ajvPath)) {
-  throw "ajv-cli not installed. Run: npm install"
+if (-not (Test-Path $ajvScriptPath)) {
+  throw "AJV validation script not found: $ajvScriptPath"
 }
 
 $schemaFiles = Get-ChildItem -Path $schemaDir -Filter *.schema.json | Sort-Object Name
@@ -28,25 +28,10 @@ if ($schemaFiles.Count -eq 0) {
 }
 
 foreach ($schemaFile in $schemaFiles) {
-  $refFiles = $schemaFiles |
-    Where-Object { $_.FullName -ne $schemaFile.FullName } |
-    ForEach-Object { $_.FullName }
-
   Write-Host "Checking JSON syntax:" $schemaFile.Name
   & $jqPath empty $schemaFile.FullName
   if ($LASTEXITCODE -ne 0) {
     throw "Invalid JSON syntax in $($schemaFile.FullName)"
-  }
-
-  Write-Host "Compiling schema:" $schemaFile.Name
-  $ajvArgs = @('compile', '--spec=draft2020', '--strict=false', '-c', 'ajv-formats', '-s', $schemaFile.FullName)
-  foreach ($refFile in $refFiles) {
-    $ajvArgs += @('-r', $refFile)
-  }
-
-  & $ajvPath @ajvArgs
-  if ($LASTEXITCODE -ne 0) {
-    throw "Schema compilation failed for $($schemaFile.FullName)"
   }
 
   $exampleBaseName = [System.IO.Path]::GetFileNameWithoutExtension(
@@ -63,17 +48,12 @@ foreach ($schemaFile in $schemaFiles) {
   if ($LASTEXITCODE -ne 0) {
     throw "Invalid JSON syntax in $examplePath"
   }
+}
 
-  Write-Host "Validating example:" ([System.IO.Path]::GetFileName($examplePath))
-  $validateArgs = @('validate', '--spec=draft2020', '--strict=false', '-c', 'ajv-formats', '-s', $schemaFile.FullName, '-d', $examplePath)
-  foreach ($refFile in $refFiles) {
-    $validateArgs += @('-r', $refFile)
-  }
-
-  & $ajvPath @validateArgs
-  if ($LASTEXITCODE -ne 0) {
-    throw "Example validation failed for $examplePath"
-  }
+Write-Host "Running AJV validation script"
+node $ajvScriptPath
+if ($LASTEXITCODE -ne 0) {
+  throw "AJV validation script failed"
 }
 
 Write-Host "Schema validation completed successfully."


### PR DESCRIPTION
…endency (#175)

- add ModelDocDocument and ModelDocBlock
- add JSON roundtrip and copyWith unit tests for docs models
- add v1 docs schemas and canonical examples
- document block-based doc semantics for blocksByIndex, content, and heading levels
- replace ajv-cli with an internal ajv-based validation script
- remove the fast-json-patch dependency chain from package-lock.json
- update changelog for 1.38.7