### PR TITLE
feat: add ai domain module and agnostic interaction contracts (#178)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,51 @@
 This document follows the guidelines of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.38.8] - 2026-03-15
+
+### Added
+- **AI domain module**
+  - Nuevo módulo `lib/domain/ai/` con:
+    - `ModelAiMessage`
+    - `ModelAiExecutionConfig`
+    - `ModelAiRequest`
+    - `ModelAiResponse`
+  - Los modelos materializan un dominio mínimo y agnóstico para interacción con modelos de IA.
+  - `ModelAiRequest` separa `systemInstruction`, `messages`, `executionConfig`, `references` y `expectedResponseSchema`.
+  - `ModelAiResponse` define una respuesta final canónica única, con soporte opcional para `parsedJson`, `finishReason` y `usage`.
+- **AI unit tests**
+  - Nuevas pruebas unitarias para:
+    - roundtrip `fromJson(toJson(model))`
+    - roundtrip `toJson(fromJson(jsonCanonico))`
+    - `copyWith`
+  - Cobertura inicial para:
+    - `ai_model_message_test.dart`
+    - `ai_model_execution_config_test.dart`
+    - `ai_model_request_test.dart`
+    - `ai_model_response_test.dart`
+- **AI JSON contracts**
+  - Nuevos schemas y examples canónicos en `doc/schemas/v1/` para:
+    - `model_ai_message.schema.json`
+    - `model_ai_execution_config.schema.json`
+    - `model_ai_request.schema.json`
+    - `model_ai_response.schema.json`
+  - Se formaliza:
+    - `taskType` explícito para `textGeneration`, `groundedTextGeneration` e `imageGeneration`
+    - `references` como lista de URLs canónicas
+    - `expectedResponseSchema` reutilizando `ModelJsonSchemaDocument`
+    - `provider` y `modelId` como strings libres para no acoplar el contrato a un proveedor concreto
+
+### Changed
+- **AI documentation**
+  - Se actualizan `doc/schemas/README.md` y `doc/schemas/v1/README.md` para reflejar:
+    - la separación entre intención agnóstica e implementación del proveedor
+    - la semántica de `taskType`, `systemInstruction` y `references`
+    - el alcance reducido de la fase:
+      - sin tool calling
+      - sin múltiples candidates
+      - sin attachments binarios
+      - sin multimodalidad avanzada más allá de la intención contractual
+
 ## [1.38.7] - 2026-03-15
 
 ### Added

--- a/doc/schemas/README.md
+++ b/doc/schemas/README.md
@@ -54,7 +54,7 @@ Notas:
 
 - `package.json` y `package-lock.json` forman parte del tooling reproducible del repo
 - `node_modules/` es solo instalación local y no debe versionarse
-- el validador usa `ajv-cli` desde `node_modules/.bin` y `jq` vendorizado en `tools/jq/jq.exe`
+- el validador usa `ajv` mediante `tools/validate-schemas.mjs` y `jq` vendorizado en `tools/jq/jq.exe`
 
 - Comando principal:
 
@@ -96,6 +96,9 @@ npm run validate:schemas
 - En contratos Docs, `title` vive fuera del cuerpo y `content` siempre se serializa como `string`.
 - El dominio tabular tipo Sheets representa filas como `idRow + data`, donde `data` es un objeto JSON gobernado por columnas declaradas en la tabla.
 - En contratos tabulares tipo Sheets, la PK efectiva siempre se serializa como `String`, incluso cuando es autogenerada.
+- El dominio de IA separa `systemInstruction`, `messages`, `executionConfig` y `expectedResponseSchema` para mantener una intencion portable entre proveedores.
+- En contratos de IA, `taskType` hace explicita la intencion de texto, grounded text o generacion de imagen sin depender solo del prompt.
+- En contratos de IA, `expectedResponseSchema` reutiliza `ModelJsonSchemaDocument` para exigir salidas JSON estructuradas sin acoplarse a un proveedor concreto.
 
 ## Brechas conocidas con la implementación Dart
 

--- a/doc/schemas/v1/README.md
+++ b/doc/schemas/v1/README.md
@@ -8,6 +8,10 @@ Esta carpeta contiene la primera version de contratos JSON canonicos para `jocaa
 - `attribute_model.schema.json`
 - `appointment_model.schema.json`
 - `acceptance_clause_model.schema.json`
+- `model_ai_execution_config.schema.json`
+- `model_ai_message.schema.json`
+- `model_ai_request.schema.json`
+- `model_ai_response.schema.json`
 - `connectivity_model.schema.json`
 - `contact_model.schema.json`
 - `dental_condition_model.schema.json`
@@ -73,6 +77,7 @@ Esta carpeta contiene la primera version de contratos JSON canonicos para `jocaa
 
 - `model_drive_file.schema.json`, `model_drive_folder.schema.json` y `model_drive_item.schema.json` forman una familia contractual alineada, pero en `v1` se mantienen como contratos completos independientes para preservar validación simple con `additionalProperties: false`
 - `model_doc_document.schema.json` referencia `model_doc_block.schema.json`
+- `model_ai_request.schema.json` referencia `model_ai_message.schema.json`, `model_ai_execution_config.schema.json` y `model_json_schema_document.schema.json`
 - `model_sheet_book.schema.json` referencia `model_sheet_table.schema.json`
 - `model_sheet_table.schema.json` referencia `model_sheet_column.schema.json`
 - `store_model.schema.json` referencia `address_model.schema.json`
@@ -138,6 +143,9 @@ Resultado esperado:
 - En contratos Docs, `ModelDocDocument` organiza el contenido mediante `blocksByIndex`
 - En contratos Docs, `ModelDocBlock.kind` se limita a `heading`, `paragraph` y `markdown`
 - En contratos Docs, `ModelDocBlock.level` solo aplica a encabezados
+- En contratos IA, `ModelAiRequest.taskType` se limita a `textGeneration`, `groundedTextGeneration` e `imageGeneration`
+- En contratos IA, `systemInstruction` se separa de `messages` para estabilizar la intención del prompt
+- En contratos IA, `references` contiene URLs canónicas y `expectedResponseSchema` reutiliza `ModelJsonSchemaDocument`
 - En contratos Sheets, `ModelSheetRow` representa un registro persistible mediante `idRow` y `data`
 - En contratos Sheets, `idRow` es la PK efectiva y siempre se serializa como `string`
 - En contratos Sheets, `data` es un objeto JSON gobernado por los nombres únicos declarados en `ModelSheetColumn`
@@ -155,6 +163,7 @@ Resultado esperado:
 - Los examples deben ser internamente consistentes con el resto de contratos reutilizados.
 - En la familia Drive, `mimeType` canónico de carpeta es `application/vnd.jocaagura.folder`.
 - En la familia Docs, el markdown libre se limita a bloques `markdown` y no se modela rich text inline.
+- En la familia IA, la respuesta canónica es única y no se modelan múltiples candidates ni tool calling en `v1`.
 - En la familia Sheets no se modelan labels visibles, fórmulas, orden visual, foreign keys ni versionado estructural.
 
 ## Brechas conocidas entre contrato y Dart actual
@@ -184,6 +193,10 @@ Resultado esperado:
 - `model_doc_document.schema.json` y `model_doc_block.schema.json`
   - formalizan el dominio mínimo de documentos por bloques.
   - la representación visual final queda deliberadamente fuera del contrato y se delega al implementador.
+- `model_ai_message.schema.json`, `model_ai_execution_config.schema.json`, `model_ai_request.schema.json` y `model_ai_response.schema.json`
+  - formalizan el dominio mínimo para interacción agnóstica con modelos de IA.
+  - el proveedor y el `modelId` quedan abiertos como strings para no acoplar el contrato a Gemini, GPT u otra API puntual.
+  - la interpretación final de `executionConfig` y de `references` sigue siendo responsabilidad del implementador.
 
 ## Compatibilidad esperada
 

--- a/doc/schemas/v1/examples/model_ai_execution_config.example.json
+++ b/doc/schemas/v1/examples/model_ai_execution_config.example.json
@@ -1,0 +1,11 @@
+{
+  "temperature": 0,
+  "topP": 0.95,
+  "topK": 40,
+  "maxOutputTokens": 512,
+  "seed": 7,
+  "stopSequences": [
+    "</json>"
+  ],
+  "deterministicPreferred": true
+}

--- a/doc/schemas/v1/examples/model_ai_message.example.json
+++ b/doc/schemas/v1/examples/model_ai_message.example.json
@@ -1,0 +1,4 @@
+{
+  "role": "user",
+  "content": "Resume la arquitectura en tres puntos."
+}

--- a/doc/schemas/v1/examples/model_ai_request.example.json
+++ b/doc/schemas/v1/examples/model_ai_request.example.json
@@ -1,0 +1,68 @@
+{
+  "id": "ai_req_customer_summary_001",
+  "provider": "gemini",
+  "modelId": "gemini-2.5-pro",
+  "taskType": "groundedTextGeneration",
+  "systemInstruction": "Responde solo con JSON valido y no agregues texto extra.",
+  "messages": [
+    {
+      "role": "user",
+      "content": "Lee las referencias y resume los puntos clave del dominio."
+    }
+  ],
+  "references": [
+    "https://example.com/domain-overview"
+  ],
+  "executionConfig": {
+    "temperature": 0,
+    "topP": 0.95,
+    "maxOutputTokens": 512,
+    "deterministicPreferred": true
+  },
+  "expectedResponseSchema": {
+    "id": "schema_ai_domain_summary_v1",
+    "schemaId": "https://jocaagura.dev/schemas/jocaagura_domain/v1/domain_summary_response.schema.json",
+    "schemaTitle": "DomainSummaryResponse",
+    "domainModel": "DomainSummaryResponse",
+    "version": "v1",
+    "schemaDescription": "Structured summary response expected from the model.",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://jocaagura.dev/schemas/jocaagura_domain/v1/domain_summary_response.schema.json",
+      "title": "DomainSummaryResponse",
+      "description": "Structured summary response expected from the model.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "summary": {
+          "type": "string"
+        },
+        "highlights": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "summary",
+        "highlights"
+      ]
+    },
+    "example": {
+      "summary": "El dominio prioriza interoperabilidad y contratos JSON canonicos.",
+      "highlights": [
+        "Schemas versionados en v1",
+        "Roundtrip JSON en modelos Dart",
+        "Base agnostica para backend y Apps Script"
+      ]
+    },
+    "tags": [
+      "ai",
+      "response"
+    ],
+    "createdAt": "2026-03-15T00:00:00.000Z",
+    "updatedAt": "2026-03-15T00:00:00.000Z",
+    "isActive": true
+  }
+}

--- a/doc/schemas/v1/examples/model_ai_response.example.json
+++ b/doc/schemas/v1/examples/model_ai_response.example.json
@@ -1,0 +1,19 @@
+{
+  "requestId": "ai_req_customer_summary_001",
+  "provider": "gemini",
+  "modelId": "gemini-2.5-pro",
+  "content": "{\"summary\":\"El dominio prioriza interoperabilidad y contratos JSON canonicos.\",\"highlights\":[\"Schemas versionados en v1\",\"Roundtrip JSON en modelos Dart\",\"Base agnostica para backend y Apps Script\"]}",
+  "parsedJson": {
+    "summary": "El dominio prioriza interoperabilidad y contratos JSON canonicos.",
+    "highlights": [
+      "Schemas versionados en v1",
+      "Roundtrip JSON en modelos Dart",
+      "Base agnostica para backend y Apps Script"
+    ]
+  },
+  "finishReason": "stop",
+  "usage": {
+    "inputTokens": 312,
+    "outputTokens": 97
+  }
+}

--- a/doc/schemas/v1/model_ai_execution_config.schema.json
+++ b/doc/schemas/v1/model_ai_execution_config.schema.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://jocaagura.dev/schemas/jocaagura_domain/v1/model_ai_execution_config.schema.json",
+  "title": "ModelAiExecutionConfig",
+  "description": "Canonical JSON contract for agnostic AI execution intent in jocaagura_domain.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "temperature": {
+      "type": "number",
+      "description": "Sampling temperature requested for the provider."
+    },
+    "topP": {
+      "type": "number",
+      "description": "Top-p nucleus sampling value requested for the provider."
+    },
+    "topK": {
+      "type": "integer",
+      "description": "Top-k sampling value requested for the provider."
+    },
+    "maxOutputTokens": {
+      "type": "integer",
+      "description": "Maximum output tokens requested for the response.",
+      "minimum": 1
+    },
+    "seed": {
+      "type": "integer",
+      "description": "Preferred deterministic seed when the provider supports it."
+    },
+    "stopSequences": {
+      "type": "array",
+      "description": "Optional list of stop sequences requested for generation.",
+      "items": {
+        "type": "string"
+      }
+    },
+    "deterministicPreferred": {
+      "type": "boolean",
+      "description": "Agnostic intent that the request should favor reproducible outputs when possible."
+    }
+  },
+  "required": [],
+  "examples": [
+    {
+      "temperature": 0,
+      "topP": 0.95,
+      "topK": 40,
+      "maxOutputTokens": 512,
+      "seed": 7,
+      "stopSequences": [
+        "</json>"
+      ],
+      "deterministicPreferred": true
+    }
+  ]
+}

--- a/doc/schemas/v1/model_ai_message.schema.json
+++ b/doc/schemas/v1/model_ai_message.schema.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://jocaagura.dev/schemas/jocaagura_domain/v1/model_ai_message.schema.json",
+  "title": "ModelAiMessage",
+  "description": "Canonical JSON contract for a conversational AI message in jocaagura_domain.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "role": {
+      "type": "string",
+      "description": "Conversational role of the message.",
+      "enum": [
+        "user",
+        "assistant"
+      ]
+    },
+    "content": {
+      "type": "string",
+      "description": "Text content of the message."
+    }
+  },
+  "required": [
+    "role",
+    "content"
+  ],
+  "examples": [
+    {
+      "role": "user",
+      "content": "Resume la arquitectura en tres puntos."
+    }
+  ]
+}

--- a/doc/schemas/v1/model_ai_request.schema.json
+++ b/doc/schemas/v1/model_ai_request.schema.json
@@ -1,0 +1,133 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://jocaagura.dev/schemas/jocaagura_domain/v1/model_ai_request.schema.json",
+  "title": "ModelAiRequest",
+  "description": "Canonical JSON contract for an agnostic AI request in jocaagura_domain.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "Unique identifier of the request."
+    },
+    "provider": {
+      "type": "string",
+      "description": "Provider identifier chosen by the implementer."
+    },
+    "modelId": {
+      "type": "string",
+      "description": "Concrete model identifier chosen by the implementer."
+    },
+    "taskType": {
+      "type": "string",
+      "description": "Canonical task intent for the AI interaction.",
+      "enum": [
+        "textGeneration",
+        "groundedTextGeneration",
+        "imageGeneration"
+      ]
+    },
+    "systemInstruction": {
+      "type": "string",
+      "description": "Optional global instruction that stabilizes behavior across the full request."
+    },
+    "messages": {
+      "type": "array",
+      "description": "Ordered conversational messages associated with the request.",
+      "items": {
+        "$ref": "./model_ai_message.schema.json"
+      }
+    },
+    "references": {
+      "type": "array",
+      "description": "Optional URL references that ground the request context.",
+      "items": {
+        "type": "string",
+        "format": "uri"
+      }
+    },
+    "executionConfig": {
+      "$ref": "./model_ai_execution_config.schema.json"
+    },
+    "expectedResponseSchema": {
+      "$ref": "./model_json_schema_document.schema.json"
+    }
+  },
+  "required": [
+    "id",
+    "provider",
+    "modelId",
+    "taskType",
+    "messages"
+  ],
+  "examples": [
+    {
+      "id": "ai_req_customer_summary_001",
+      "provider": "gemini",
+      "modelId": "gemini-2.5-pro",
+      "taskType": "groundedTextGeneration",
+      "systemInstruction": "Responde solo con JSON valido y no agregues texto extra.",
+      "messages": [
+        {
+          "role": "user",
+          "content": "Lee las referencias y resume los puntos clave del dominio."
+        }
+      ],
+      "references": [
+        "https://example.com/domain-overview"
+      ],
+      "executionConfig": {
+        "temperature": 0,
+        "topP": 0.95,
+        "maxOutputTokens": 512,
+        "deterministicPreferred": true
+      },
+      "expectedResponseSchema": {
+        "id": "schema_ai_domain_summary_v1",
+        "schemaId": "https://jocaagura.dev/schemas/jocaagura_domain/v1/domain_summary_response.schema.json",
+        "schemaTitle": "DomainSummaryResponse",
+        "domainModel": "DomainSummaryResponse",
+        "version": "v1",
+        "schemaDescription": "Structured summary response expected from the model.",
+        "schema": {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "$id": "https://jocaagura.dev/schemas/jocaagura_domain/v1/domain_summary_response.schema.json",
+          "title": "DomainSummaryResponse",
+          "description": "Structured summary response expected from the model.",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "summary": {
+              "type": "string"
+            },
+            "highlights": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "required": [
+            "summary",
+            "highlights"
+          ]
+        },
+        "example": {
+          "summary": "El dominio prioriza interoperabilidad y contratos JSON canonicos.",
+          "highlights": [
+            "Schemas versionados en v1",
+            "Roundtrip JSON en modelos Dart",
+            "Base agnostica para backend y Apps Script"
+          ]
+        },
+        "tags": [
+          "ai",
+          "response"
+        ],
+        "createdAt": "2026-03-15T00:00:00.000Z",
+        "updatedAt": "2026-03-15T00:00:00.000Z",
+        "isActive": true
+      }
+    }
+  ]
+}

--- a/doc/schemas/v1/model_ai_response.schema.json
+++ b/doc/schemas/v1/model_ai_response.schema.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://jocaagura.dev/schemas/jocaagura_domain/v1/model_ai_response.schema.json",
+  "title": "ModelAiResponse",
+  "description": "Canonical JSON contract for a final agnostic AI response in jocaagura_domain.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "requestId": {
+      "type": "string",
+      "description": "Identifier of the request that originated this response."
+    },
+    "provider": {
+      "type": "string",
+      "description": "Provider identifier that produced the response."
+    },
+    "modelId": {
+      "type": "string",
+      "description": "Concrete model identifier that produced the response."
+    },
+    "content": {
+      "type": "string",
+      "description": "Final textual content returned by the model."
+    },
+    "parsedJson": {
+      "type": "object",
+      "description": "Optional parsed JSON payload when the response is meant to satisfy a structured contract.",
+      "additionalProperties": true
+    },
+    "finishReason": {
+      "type": "string",
+      "description": "Provider finish reason normalized as a free string."
+    },
+    "usage": {
+      "type": "object",
+      "description": "Optional usage metadata returned by the provider.",
+      "additionalProperties": true
+    }
+  },
+  "required": [
+    "requestId",
+    "provider",
+    "modelId",
+    "content"
+  ],
+  "examples": [
+    {
+      "requestId": "ai_req_customer_summary_001",
+      "provider": "gemini",
+      "modelId": "gemini-2.5-pro",
+      "content": "{\"summary\":\"El dominio prioriza interoperabilidad y contratos JSON canonicos.\",\"highlights\":[\"Schemas versionados en v1\",\"Roundtrip JSON en modelos Dart\",\"Base agnostica para backend y Apps Script\"]}",
+      "parsedJson": {
+        "summary": "El dominio prioriza interoperabilidad y contratos JSON canonicos.",
+        "highlights": [
+          "Schemas versionados en v1",
+          "Roundtrip JSON en modelos Dart",
+          "Base agnostica para backend y Apps Script"
+        ]
+      },
+      "finishReason": "stop",
+      "usage": {
+        "inputTokens": 312,
+        "outputTokens": 97
+      }
+    }
+  ]
+}

--- a/lib/domain/ai/model_ai_execution_config.dart
+++ b/lib/domain/ai/model_ai_execution_config.dart
@@ -1,0 +1,163 @@
+part of 'package:jocaagura_domain/jocaagura_domain.dart';
+
+/// Stable JSON keys used by [ModelAiExecutionConfig].
+enum ModelAiExecutionConfigEnum {
+  temperature,
+  topP,
+  topK,
+  maxOutputTokens,
+  seed,
+  stopSequences,
+  deterministicPreferred,
+}
+
+/// Agnostic execution intent for an AI inference request.
+class ModelAiExecutionConfig extends Model {
+  const ModelAiExecutionConfig({
+    this.temperature,
+    this.topP,
+    this.topK,
+    this.maxOutputTokens,
+    this.seed,
+    this.stopSequences,
+    this.deterministicPreferred,
+  });
+
+  factory ModelAiExecutionConfig.fromJson(Map<String, dynamic> json) {
+    return ModelAiExecutionConfig(
+      temperature: json.containsKey(ModelAiExecutionConfigEnum.temperature.name)
+          ? _aiNullableDoubleFromDynamic(
+              json[ModelAiExecutionConfigEnum.temperature.name],
+            )
+          : null,
+      topP: json.containsKey(ModelAiExecutionConfigEnum.topP.name)
+          ? _aiNullableDoubleFromDynamic(
+              json[ModelAiExecutionConfigEnum.topP.name],
+            )
+          : null,
+      topK: json.containsKey(ModelAiExecutionConfigEnum.topK.name)
+          ? Utils.getIntegerFromDynamic(
+              json[ModelAiExecutionConfigEnum.topK.name],
+            )
+          : null,
+      maxOutputTokens:
+          json.containsKey(ModelAiExecutionConfigEnum.maxOutputTokens.name)
+              ? Utils.getIntegerFromDynamic(
+                  json[ModelAiExecutionConfigEnum.maxOutputTokens.name],
+                )
+              : null,
+      seed: json.containsKey(ModelAiExecutionConfigEnum.seed.name)
+          ? Utils.getIntegerFromDynamic(
+              json[ModelAiExecutionConfigEnum.seed.name],
+            )
+          : null,
+      stopSequences:
+          json.containsKey(ModelAiExecutionConfigEnum.stopSequences.name)
+              ? Utils.stringListFromDynamic(
+                  json[ModelAiExecutionConfigEnum.stopSequences.name],
+                )
+              : null,
+      deterministicPreferred: json.containsKey(
+        ModelAiExecutionConfigEnum.deterministicPreferred.name,
+      )
+          ? Utils.getBoolFromDynamic(
+              json[ModelAiExecutionConfigEnum.deterministicPreferred.name],
+            )
+          : null,
+    );
+  }
+
+  final double? temperature;
+  final double? topP;
+  final int? topK;
+  final int? maxOutputTokens;
+  final int? seed;
+  final List<String>? stopSequences;
+  final bool? deterministicPreferred;
+
+  @override
+  ModelAiExecutionConfig copyWith({
+    Object? temperature = _aiUnset,
+    Object? topP = _aiUnset,
+    Object? topK = _aiUnset,
+    Object? maxOutputTokens = _aiUnset,
+    Object? seed = _aiUnset,
+    Object? stopSequences = _aiUnset,
+    Object? deterministicPreferred = _aiUnset,
+  }) {
+    return ModelAiExecutionConfig(
+      temperature: identical(temperature, _aiUnset)
+          ? this.temperature
+          : temperature as double?,
+      topP: identical(topP, _aiUnset) ? this.topP : topP as double?,
+      topK: identical(topK, _aiUnset) ? this.topK : topK as int?,
+      maxOutputTokens: identical(maxOutputTokens, _aiUnset)
+          ? this.maxOutputTokens
+          : maxOutputTokens as int?,
+      seed: identical(seed, _aiUnset) ? this.seed : seed as int?,
+      stopSequences: identical(stopSequences, _aiUnset)
+          ? this.stopSequences
+          : stopSequences as List<String>?,
+      deterministicPreferred: identical(deterministicPreferred, _aiUnset)
+          ? this.deterministicPreferred
+          : deterministicPreferred as bool?,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> json = <String, dynamic>{};
+
+    if (temperature != null) {
+      json[ModelAiExecutionConfigEnum.temperature.name] = temperature;
+    }
+    if (topP != null) {
+      json[ModelAiExecutionConfigEnum.topP.name] = topP;
+    }
+    if (topK != null) {
+      json[ModelAiExecutionConfigEnum.topK.name] = topK;
+    }
+    if (maxOutputTokens != null) {
+      json[ModelAiExecutionConfigEnum.maxOutputTokens.name] = maxOutputTokens;
+    }
+    if (seed != null) {
+      json[ModelAiExecutionConfigEnum.seed.name] = seed;
+    }
+    if (stopSequences != null) {
+      json[ModelAiExecutionConfigEnum.stopSequences.name] = stopSequences;
+    }
+    if (deterministicPreferred != null) {
+      json[ModelAiExecutionConfigEnum.deterministicPreferred.name] =
+          deterministicPreferred;
+    }
+
+    return json;
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ModelAiExecutionConfig &&
+          runtimeType == other.runtimeType &&
+          temperature == other.temperature &&
+          topP == other.topP &&
+          topK == other.topK &&
+          maxOutputTokens == other.maxOutputTokens &&
+          seed == other.seed &&
+          Utils.deepEqualsDynamic(stopSequences, other.stopSequences) &&
+          deterministicPreferred == other.deterministicPreferred;
+
+  @override
+  int get hashCode => Object.hash(
+        temperature,
+        topP,
+        topK,
+        maxOutputTokens,
+        seed,
+        Utils.deepHash(stopSequences),
+        deterministicPreferred,
+      );
+
+  @override
+  String toString() => 'ModelAiExecutionConfig(${toJson()})';
+}

--- a/lib/domain/ai/model_ai_message.dart
+++ b/lib/domain/ai/model_ai_message.dart
@@ -1,0 +1,67 @@
+part of 'package:jocaagura_domain/jocaagura_domain.dart';
+
+/// Stable JSON keys used by [ModelAiMessage].
+enum ModelAiMessageEnum {
+  role,
+  content,
+}
+
+/// Canonical conversational roles supported in the agnostic AI contract.
+enum ModelAiMessageRoleEnum {
+  user,
+  assistant,
+}
+
+/// Minimal conversational message for AI interactions.
+class ModelAiMessage extends Model {
+  const ModelAiMessage({
+    required this.role,
+    required this.content,
+  });
+
+  factory ModelAiMessage.fromJson(Map<String, dynamic> json) {
+    return ModelAiMessage(
+      role: Utils.enumFromJson<ModelAiMessageRoleEnum>(
+        ModelAiMessageRoleEnum.values,
+        Utils.getStringFromDynamic(json[ModelAiMessageEnum.role.name]),
+        ModelAiMessageRoleEnum.user,
+      ),
+      content:
+          Utils.getStringFromDynamic(json[ModelAiMessageEnum.content.name]),
+    );
+  }
+
+  final ModelAiMessageRoleEnum role;
+  final String content;
+
+  @override
+  ModelAiMessage copyWith({
+    ModelAiMessageRoleEnum? role,
+    String? content,
+  }) {
+    return ModelAiMessage(
+      role: role ?? this.role,
+      content: content ?? this.content,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        ModelAiMessageEnum.role.name: role.name,
+        ModelAiMessageEnum.content.name: content,
+      };
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ModelAiMessage &&
+          runtimeType == other.runtimeType &&
+          role == other.role &&
+          content == other.content;
+
+  @override
+  int get hashCode => Object.hash(role, content);
+
+  @override
+  String toString() => 'ModelAiMessage(${toJson()})';
+}

--- a/lib/domain/ai/model_ai_request.dart
+++ b/lib/domain/ai/model_ai_request.dart
@@ -1,0 +1,184 @@
+part of 'package:jocaagura_domain/jocaagura_domain.dart';
+
+/// Stable JSON keys used by [ModelAiRequest].
+enum ModelAiRequestEnum {
+  id,
+  provider,
+  modelId,
+  taskType,
+  systemInstruction,
+  messages,
+  references,
+  executionConfig,
+  expectedResponseSchema,
+}
+
+/// Canonical agnostic AI task kinds.
+enum ModelAiTaskTypeEnum {
+  textGeneration,
+  groundedTextGeneration,
+  imageGeneration,
+}
+
+/// Canonical AI request portable across providers.
+class ModelAiRequest extends Model {
+  const ModelAiRequest({
+    required this.id,
+    required this.provider,
+    required this.modelId,
+    required this.taskType,
+    required this.messages,
+    this.systemInstruction,
+    this.references,
+    this.executionConfig,
+    this.expectedResponseSchema,
+  });
+
+  factory ModelAiRequest.fromJson(Map<String, dynamic> json) {
+    return ModelAiRequest(
+      id: Utils.getStringFromDynamic(json[ModelAiRequestEnum.id.name]),
+      provider:
+          Utils.getStringFromDynamic(json[ModelAiRequestEnum.provider.name]),
+      modelId:
+          Utils.getStringFromDynamic(json[ModelAiRequestEnum.modelId.name]),
+      taskType: Utils.enumFromJson<ModelAiTaskTypeEnum>(
+        ModelAiTaskTypeEnum.values,
+        Utils.getStringFromDynamic(json[ModelAiRequestEnum.taskType.name]),
+        ModelAiTaskTypeEnum.textGeneration,
+      ),
+      systemInstruction: json.containsKey(
+        ModelAiRequestEnum.systemInstruction.name,
+      )
+          ? _aiNullableStringFromDynamic(
+              json[ModelAiRequestEnum.systemInstruction.name],
+            )
+          : null,
+      messages: Utils.listFromDynamic(json[ModelAiRequestEnum.messages.name])
+          .map((Map<String, dynamic> e) => ModelAiMessage.fromJson(e))
+          .toList(),
+      references: json.containsKey(ModelAiRequestEnum.references.name)
+          ? Utils.stringListFromDynamic(
+              json[ModelAiRequestEnum.references.name],
+            )
+          : null,
+      executionConfig: json.containsKey(ModelAiRequestEnum.executionConfig.name)
+          ? ModelAiExecutionConfig.fromJson(
+              Utils.mapFromDynamic(
+                json[ModelAiRequestEnum.executionConfig.name],
+              ),
+            )
+          : null,
+      expectedResponseSchema: json.containsKey(
+        ModelAiRequestEnum.expectedResponseSchema.name,
+      )
+          ? ModelJsonSchemaDocument.fromJson(
+              Utils.mapFromDynamic(
+                json[ModelAiRequestEnum.expectedResponseSchema.name],
+              ),
+            )
+          : null,
+    );
+  }
+
+  final String id;
+  final String provider;
+  final String modelId;
+  final ModelAiTaskTypeEnum taskType;
+  final String? systemInstruction;
+  final List<ModelAiMessage> messages;
+  final List<String>? references;
+  final ModelAiExecutionConfig? executionConfig;
+  final ModelJsonSchemaDocument? expectedResponseSchema;
+
+  @override
+  ModelAiRequest copyWith({
+    String? id,
+    String? provider,
+    String? modelId,
+    ModelAiTaskTypeEnum? taskType,
+    Object? systemInstruction = _aiUnset,
+    List<ModelAiMessage>? messages,
+    Object? references = _aiUnset,
+    Object? executionConfig = _aiUnset,
+    Object? expectedResponseSchema = _aiUnset,
+  }) {
+    return ModelAiRequest(
+      id: id ?? this.id,
+      provider: provider ?? this.provider,
+      modelId: modelId ?? this.modelId,
+      taskType: taskType ?? this.taskType,
+      systemInstruction: identical(systemInstruction, _aiUnset)
+          ? this.systemInstruction
+          : systemInstruction as String?,
+      messages: messages ?? this.messages,
+      references: identical(references, _aiUnset)
+          ? this.references
+          : references as List<String>?,
+      executionConfig: identical(executionConfig, _aiUnset)
+          ? this.executionConfig
+          : executionConfig as ModelAiExecutionConfig?,
+      expectedResponseSchema: identical(expectedResponseSchema, _aiUnset)
+          ? this.expectedResponseSchema
+          : expectedResponseSchema as ModelJsonSchemaDocument?,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> json = <String, dynamic>{
+      ModelAiRequestEnum.id.name: id,
+      ModelAiRequestEnum.provider.name: provider,
+      ModelAiRequestEnum.modelId.name: modelId,
+      ModelAiRequestEnum.taskType.name: taskType.name,
+      ModelAiRequestEnum.messages.name:
+          messages.map((ModelAiMessage e) => e.toJson()).toList(),
+    };
+
+    if (systemInstruction != null) {
+      json[ModelAiRequestEnum.systemInstruction.name] = systemInstruction;
+    }
+    if (references != null) {
+      json[ModelAiRequestEnum.references.name] = references;
+    }
+    if (executionConfig != null) {
+      json[ModelAiRequestEnum.executionConfig.name] = executionConfig!.toJson();
+    }
+    if (expectedResponseSchema != null) {
+      json[ModelAiRequestEnum.expectedResponseSchema.name] =
+          expectedResponseSchema!.toJson();
+    }
+
+    return json;
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ModelAiRequest &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          provider == other.provider &&
+          modelId == other.modelId &&
+          taskType == other.taskType &&
+          systemInstruction == other.systemInstruction &&
+          Utils.listEquals(messages, other.messages) &&
+          Utils.deepEqualsDynamic(references, other.references) &&
+          executionConfig == other.executionConfig &&
+          expectedResponseSchema == other.expectedResponseSchema;
+
+  @override
+  int get hashCode => Object.hash(
+        id,
+        provider,
+        modelId,
+        taskType,
+        systemInstruction,
+        Utils.listHash(messages),
+        Utils.deepHash(references),
+        executionConfig,
+        expectedResponseSchema,
+      );
+
+  @override
+  String toString() => 'ModelAiRequest(${toJson()})';
+}

--- a/lib/domain/ai/model_ai_response.dart
+++ b/lib/domain/ai/model_ai_response.dart
@@ -1,0 +1,157 @@
+part of 'package:jocaagura_domain/jocaagura_domain.dart';
+
+/// Stable JSON keys used by [ModelAiResponse].
+enum ModelAiResponseEnum {
+  requestId,
+  provider,
+  modelId,
+  content,
+  parsedJson,
+  finishReason,
+  usage,
+}
+
+/// Canonical final AI response for a request.
+class ModelAiResponse extends Model {
+  const ModelAiResponse({
+    required this.requestId,
+    required this.provider,
+    required this.modelId,
+    required this.content,
+    this.parsedJson,
+    this.finishReason,
+    this.usage,
+  });
+
+  factory ModelAiResponse.fromJson(Map<String, dynamic> json) {
+    return ModelAiResponse(
+      requestId:
+          Utils.getStringFromDynamic(json[ModelAiResponseEnum.requestId.name]),
+      provider:
+          Utils.getStringFromDynamic(json[ModelAiResponseEnum.provider.name]),
+      modelId:
+          Utils.getStringFromDynamic(json[ModelAiResponseEnum.modelId.name]),
+      content:
+          Utils.getStringFromDynamic(json[ModelAiResponseEnum.content.name]),
+      parsedJson: json.containsKey(ModelAiResponseEnum.parsedJson.name)
+          ? Utils.mapFromDynamic(json[ModelAiResponseEnum.parsedJson.name])
+          : null,
+      finishReason: json.containsKey(ModelAiResponseEnum.finishReason.name)
+          ? _aiNullableStringFromDynamic(
+              json[ModelAiResponseEnum.finishReason.name],
+            )
+          : null,
+      usage: json.containsKey(ModelAiResponseEnum.usage.name)
+          ? Utils.mapFromDynamic(json[ModelAiResponseEnum.usage.name])
+          : null,
+    );
+  }
+
+  final String requestId;
+  final String provider;
+  final String modelId;
+  final String content;
+  final Map<String, dynamic>? parsedJson;
+  final String? finishReason;
+  final Map<String, dynamic>? usage;
+
+  @override
+  ModelAiResponse copyWith({
+    String? requestId,
+    String? provider,
+    String? modelId,
+    String? content,
+    Object? parsedJson = _aiUnset,
+    Object? finishReason = _aiUnset,
+    Object? usage = _aiUnset,
+  }) {
+    return ModelAiResponse(
+      requestId: requestId ?? this.requestId,
+      provider: provider ?? this.provider,
+      modelId: modelId ?? this.modelId,
+      content: content ?? this.content,
+      parsedJson: identical(parsedJson, _aiUnset)
+          ? this.parsedJson
+          : parsedJson as Map<String, dynamic>?,
+      finishReason: identical(finishReason, _aiUnset)
+          ? this.finishReason
+          : finishReason as String?,
+      usage: identical(usage, _aiUnset)
+          ? this.usage
+          : usage as Map<String, dynamic>?,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> json = <String, dynamic>{
+      ModelAiResponseEnum.requestId.name: requestId,
+      ModelAiResponseEnum.provider.name: provider,
+      ModelAiResponseEnum.modelId.name: modelId,
+      ModelAiResponseEnum.content.name: content,
+    };
+
+    if (parsedJson != null) {
+      json[ModelAiResponseEnum.parsedJson.name] = parsedJson;
+    }
+    if (finishReason != null) {
+      json[ModelAiResponseEnum.finishReason.name] = finishReason;
+    }
+    if (usage != null) {
+      json[ModelAiResponseEnum.usage.name] = usage;
+    }
+
+    return json;
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ModelAiResponse &&
+          runtimeType == other.runtimeType &&
+          requestId == other.requestId &&
+          provider == other.provider &&
+          modelId == other.modelId &&
+          content == other.content &&
+          Utils.deepEqualsDynamic(parsedJson, other.parsedJson) &&
+          finishReason == other.finishReason &&
+          Utils.deepEqualsDynamic(usage, other.usage);
+
+  @override
+  int get hashCode => Object.hash(
+        requestId,
+        provider,
+        modelId,
+        content,
+        Utils.deepHash(parsedJson),
+        finishReason,
+        Utils.deepHash(usage),
+      );
+
+  @override
+  String toString() => 'ModelAiResponse(${toJson()})';
+}
+
+const Object _aiUnset = Object();
+
+String? _aiNullableStringFromDynamic(dynamic value) {
+  if (value == null) {
+    return null;
+  }
+  final String parsed = Utils.getStringFromDynamic(value);
+  return parsed.isEmpty ? null : parsed;
+}
+
+double? _aiNullableDoubleFromDynamic(dynamic value) {
+  if (value == null) {
+    return null;
+  }
+  if (value is num) {
+    return value.toDouble();
+  }
+  final String normalized = value.toString().trim();
+  if (normalized.isEmpty) {
+    return null;
+  }
+  return double.tryParse(normalized);
+}

--- a/lib/jocaagura_domain.dart
+++ b/lib/jocaagura_domain.dart
@@ -34,6 +34,10 @@ export 'src/repositories/repository_ws_database_impl.dart';
 
 part 'date_utils.dart';
 part 'domain/address_model.dart';
+part 'domain/ai/model_ai_execution_config.dart';
+part 'domain/ai/model_ai_message.dart';
+part 'domain/ai/model_ai_request.dart';
+part 'domain/ai/model_ai_response.dart';
 part 'domain/apps/model_acl.dart';
 part 'domain/apps/model_acl_policy.dart';
 part 'domain/apps/model_app_version.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: jocaagura_domain
 description: "A package with domain models for all transversal applications"
 
-version: 1.38.7
+version: 1.38.8
 
 homepage: https://github.com/jocaagura/jocaagura_domain
 repository: https://github.com/jocaagura/jocaagura_domain

--- a/test/domain/ai_model_execution_config_test.dart
+++ b/test/domain/ai_model_execution_config_test.dart
@@ -1,0 +1,64 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jocaagura_domain/jocaagura_domain.dart';
+
+void main() {
+  group('ModelAiExecutionConfig', () {
+    const ModelAiExecutionConfig config = ModelAiExecutionConfig(
+      temperature: 0,
+      topP: 0.95,
+      topK: 40,
+      maxOutputTokens: 512,
+      seed: 7,
+      stopSequences: <String>['</json>'],
+      deterministicPreferred: true,
+    );
+
+    test(
+      'Given a canonical config When toJson and fromJson Then preserves the contract',
+      () {
+        final Map<String, dynamic> json = config.toJson();
+        final ModelAiExecutionConfig roundtrip =
+            ModelAiExecutionConfig.fromJson(json);
+
+        expect(roundtrip, config);
+        expect(roundtrip.toJson(), config.toJson());
+      },
+    );
+
+    test(
+      'Given canonical JSON When fromJson and toJson Then preserves JSON roundtrip',
+      () {
+        final Map<String, dynamic> json = <String, dynamic>{
+          ModelAiExecutionConfigEnum.temperature.name: 0,
+          ModelAiExecutionConfigEnum.topP.name: 0.95,
+          ModelAiExecutionConfigEnum.topK.name: 40,
+          ModelAiExecutionConfigEnum.maxOutputTokens.name: 512,
+          ModelAiExecutionConfigEnum.seed.name: 7,
+          ModelAiExecutionConfigEnum.stopSequences.name: <String>['</json>'],
+          ModelAiExecutionConfigEnum.deterministicPreferred.name: true,
+        };
+
+        final ModelAiExecutionConfig parsed =
+            ModelAiExecutionConfig.fromJson(json);
+
+        expect(parsed.toJson(), json);
+      },
+    );
+
+    test(
+      'Given a config When copyWith overrides fields Then returns updated copy',
+      () {
+        final ModelAiExecutionConfig copy = config.copyWith(
+          maxOutputTokens: 256,
+          stopSequences: <String>['END'],
+          deterministicPreferred: false,
+        );
+
+        expect(copy.maxOutputTokens, 256);
+        expect(copy.stopSequences, <String>['END']);
+        expect(copy.deterministicPreferred, false);
+        expect(copy, isNot(config));
+      },
+    );
+  });
+}

--- a/test/domain/ai_model_message_test.dart
+++ b/test/domain/ai_model_message_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jocaagura_domain/jocaagura_domain.dart';
+
+void main() {
+  group('ModelAiMessage', () {
+    const ModelAiMessage message = ModelAiMessage(
+      role: ModelAiMessageRoleEnum.user,
+      content: 'Resume la arquitectura en tres puntos.',
+    );
+
+    test(
+      'Given a canonical message When toJson and fromJson Then preserves the contract',
+      () {
+        final Map<String, dynamic> json = message.toJson();
+        final ModelAiMessage roundtrip = ModelAiMessage.fromJson(json);
+
+        expect(roundtrip, message);
+        expect(roundtrip.toJson(), message.toJson());
+      },
+    );
+
+    test(
+      'Given canonical JSON When fromJson and toJson Then preserves JSON roundtrip',
+      () {
+        final Map<String, dynamic> json = <String, dynamic>{
+          ModelAiMessageEnum.role.name: 'assistant',
+          ModelAiMessageEnum.content.name:
+              'El dominio prioriza contratos JSON canonicos.',
+        };
+
+        final ModelAiMessage parsed = ModelAiMessage.fromJson(json);
+
+        expect(parsed.toJson(), json);
+      },
+    );
+
+    test(
+      'Given a message When copyWith overrides fields Then returns updated copy',
+      () {
+        final ModelAiMessage copy = message.copyWith(
+          role: ModelAiMessageRoleEnum.assistant,
+          content: 'El dominio prioriza interoperabilidad.',
+        );
+
+        expect(copy.role, ModelAiMessageRoleEnum.assistant);
+        expect(copy.content, 'El dominio prioriza interoperabilidad.');
+        expect(copy, isNot(message));
+      },
+    );
+  });
+}

--- a/test/domain/ai_model_request_test.dart
+++ b/test/domain/ai_model_request_test.dart
@@ -1,0 +1,109 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jocaagura_domain/jocaagura_domain.dart';
+
+void main() {
+  group('ModelAiRequest', () {
+    final ModelJsonSchemaDocument expectedSchema = ModelJsonSchemaDocument(
+      id: 'schema_ai_domain_summary_v1',
+      schemaId:
+          'https://jocaagura.dev/schemas/jocaagura_domain/v1/domain_summary_response.schema.json',
+      schemaTitle: 'DomainSummaryResponse',
+      domainModel: 'DomainSummaryResponse',
+      version: 'v1',
+      schemaDescription: 'Structured summary response expected from the model.',
+      schema: const <String, dynamic>{
+        r'$schema': 'https://json-schema.org/draft/2020-12/schema',
+        r'$id':
+            'https://jocaagura.dev/schemas/jocaagura_domain/v1/domain_summary_response.schema.json',
+        'title': 'DomainSummaryResponse',
+        'description': 'Structured summary response expected from the model.',
+        'type': 'object',
+        'additionalProperties': false,
+        'properties': <String, dynamic>{
+          'summary': <String, dynamic>{'type': 'string'},
+          'highlights': <String, dynamic>{
+            'type': 'array',
+            'items': <String, dynamic>{'type': 'string'},
+          },
+        },
+        'required': <String>['summary', 'highlights'],
+      },
+      example: const <String, dynamic>{
+        'summary':
+            'El dominio prioriza interoperabilidad y contratos JSON canonicos.',
+        'highlights': <String>[
+          'Schemas versionados en v1',
+          'Roundtrip JSON en modelos Dart',
+          'Base agnostica para backend y Apps Script',
+        ],
+      },
+      tags: const <String>['ai', 'response'],
+      createdAt: DateTime.parse('2026-03-15T00:00:00.000Z'),
+      updatedAt: DateTime.parse('2026-03-15T00:00:00.000Z'),
+      isActive: true,
+    );
+
+    final ModelAiRequest request = ModelAiRequest(
+      id: 'ai_req_customer_summary_001',
+      provider: 'gemini',
+      modelId: 'gemini-2.5-pro',
+      taskType: ModelAiTaskTypeEnum.groundedTextGeneration,
+      systemInstruction:
+          'Responde solo con JSON valido y no agregues texto extra.',
+      messages: const <ModelAiMessage>[
+        ModelAiMessage(
+          role: ModelAiMessageRoleEnum.user,
+          content: 'Lee las referencias y resume los puntos clave del dominio.',
+        ),
+      ],
+      references: const <String>['https://example.com/domain-overview'],
+      executionConfig: const ModelAiExecutionConfig(
+        temperature: 0,
+        topP: 0.95,
+        maxOutputTokens: 512,
+        deterministicPreferred: true,
+      ),
+      expectedResponseSchema: expectedSchema,
+    );
+
+    test(
+      'Given a canonical request When toJson and fromJson Then preserves the contract',
+      () {
+        final Map<String, dynamic> json = request.toJson();
+        final ModelAiRequest roundtrip = ModelAiRequest.fromJson(json);
+
+        expect(roundtrip, request);
+        expect(roundtrip.toJson(), request.toJson());
+      },
+    );
+
+    test(
+      'Given canonical JSON When fromJson and toJson Then preserves JSON roundtrip',
+      () {
+        final Map<String, dynamic> json = request.toJson();
+
+        final ModelAiRequest parsed = ModelAiRequest.fromJson(json);
+
+        expect(parsed.toJson(), json);
+      },
+    );
+
+    test(
+      'Given a request When copyWith overrides fields Then returns updated copy',
+      () {
+        final ModelAiRequest copy = request.copyWith(
+          provider: 'openai',
+          modelId: 'gpt-5.4',
+          taskType: ModelAiTaskTypeEnum.textGeneration,
+          references: <String>['https://example.com/brief'],
+        );
+
+        expect(copy.provider, 'openai');
+        expect(copy.modelId, 'gpt-5.4');
+        expect(copy.taskType, ModelAiTaskTypeEnum.textGeneration);
+        expect(copy.references, <String>['https://example.com/brief']);
+        expect(copy, isNot(request));
+      },
+    );
+  });
+}

--- a/test/domain/ai_model_response_test.dart
+++ b/test/domain/ai_model_response_test.dart
@@ -1,0 +1,66 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jocaagura_domain/jocaagura_domain.dart';
+
+void main() {
+  group('ModelAiResponse', () {
+    const ModelAiResponse response = ModelAiResponse(
+      requestId: 'ai_req_customer_summary_001',
+      provider: 'gemini',
+      modelId: 'gemini-2.5-pro',
+      content:
+          '{"summary":"El dominio prioriza interoperabilidad y contratos JSON canonicos.","highlights":["Schemas versionados en v1","Roundtrip JSON en modelos Dart","Base agnostica para backend y Apps Script"]}',
+      parsedJson: <String, dynamic>{
+        'summary':
+            'El dominio prioriza interoperabilidad y contratos JSON canonicos.',
+        'highlights': <String>[
+          'Schemas versionados en v1',
+          'Roundtrip JSON en modelos Dart',
+          'Base agnostica para backend y Apps Script',
+        ],
+      },
+      finishReason: 'stop',
+      usage: <String, dynamic>{
+        'inputTokens': 312,
+        'outputTokens': 97,
+      },
+    );
+
+    test(
+      'Given a canonical response When toJson and fromJson Then preserves the contract',
+      () {
+        final Map<String, dynamic> json = response.toJson();
+        final ModelAiResponse roundtrip = ModelAiResponse.fromJson(json);
+
+        expect(roundtrip, response);
+        expect(roundtrip.toJson(), response.toJson());
+      },
+    );
+
+    test(
+      'Given canonical JSON When fromJson and toJson Then preserves JSON roundtrip',
+      () {
+        final Map<String, dynamic> json = response.toJson();
+
+        final ModelAiResponse parsed = ModelAiResponse.fromJson(json);
+
+        expect(parsed.toJson(), json);
+      },
+    );
+
+    test(
+      'Given a response When copyWith overrides fields Then returns updated copy',
+      () {
+        final ModelAiResponse copy = response.copyWith(
+          provider: 'openai',
+          modelId: 'gpt-5.4',
+          finishReason: 'completed',
+        );
+
+        expect(copy.provider, 'openai');
+        expect(copy.modelId, 'gpt-5.4');
+        expect(copy.finishReason, 'completed');
+        expect(copy, isNot(response));
+      },
+    );
+  });
+}


### PR DESCRIPTION
- add ModelAiMessage, ModelAiExecutionConfig, ModelAiRequest, and ModelAiResponse
- add JSON roundtrip and copyWith unit tests for ai models
- add v1 ai schemas and canonical examples
- document agnostic AI contract semantics for taskType, systemInstruction, references, and expectedResponseSchema
- update changelog for 1.38.8