### PR TITLE
feat: add acl plan domain models and batch assignment contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Recent entries aim to follow a normalized structure. Older historical entries may preserve some original headings where reclassification would risk changing the original intent.
 
+## [1.39.2] - 2026-03-20
+
+### Added
+- **ACL plan domain module**
+  - Nuevos modelos reutilizables para agrupación funcional de ACLs:
+    - `ModelAclPlan`
+    - `ModelAclPlanAssignment`
+  - `ModelAclPlan` define bundles de grants concretos reutilizando `ModelAcl` completo.
+  - `ModelAclPlanAssignment` conserva el plan completo embebido como snapshot histórico de asignación a usuario.
+- **ACL plan unit tests**
+  - Nuevas pruebas unitarias para:
+    - roundtrip `fromJson(toJson(model))`
+    - roundtrip `toJson(fromJson(jsonCanonico))`
+    - `copyWith`
+  - Cobertura inicial para:
+    - `acl_model_plan_test.dart`
+    - `acl_model_plan_assignment_test.dart`
+- **ACL plan JSON contracts**
+  - Nuevos schemas y examples canónicos en `doc/schemas/v1/` para:
+    - `model_acl_plan.schema.json`
+    - `model_acl_plan_assignment.schema.json`
+  - Se formaliza:
+    - agrupación ACL reusable como plan funcional
+    - asignación batch auditable mediante snapshot embebido
+    - reutilización explícita de `ModelAcl` y `UserModel`
+
+### Changed
+- **ACL schema documentation**
+  - Se actualizan `doc/schemas/README.md` y `doc/schemas/v1/README.md` para reflejar:
+    - la diferencia entre grant individual, política, plan y asignación
+    - el uso de snapshots embebidos en `ModelAclPlanAssignment`
+    - la brecha heredada de `UserModel.jwt` cuando una asignación serializa `targetUser` o `assignedBy`
+- **Branch work plan**
+  - Se reemplaza `plan-de-trabajo.md` con el plan de ejecución cerrado para la fase ACL Plan.
+
 ## [1.39.1] - 2026-03-19
 
 ### Docs

--- a/doc/schemas/README.md
+++ b/doc/schemas/README.md
@@ -104,6 +104,7 @@ npm run validate:schemas
 - En contratos de IA, `expectedResponseSchema` reutiliza `ModelJsonSchemaDocument` para exigir salidas JSON estructuradas sin acoplarse a un proveedor concreto.
 - El dominio de certificación de flujos envuelve `ModelCompleteFlow` dentro de `ModelFlowCertificate` para convertir una plantilla lineal en evidencia auditable de cumplimiento.
 - En contratos de certificación de flujo, la certificación final es explícita, no automática, y un estado `certified` implica cierre lógico del proceso.
+- El dominio ACL agrupado introduce `ModelAclPlan` como bundle reusable de grants y `ModelAclPlanAssignment` como snapshot auditable de asignación a usuario.
 
 ## Brechas conocidas con la implementación Dart
 
@@ -123,5 +124,9 @@ npm run validate:schemas
   - embebe `candidate` y `certifiedBy` como `UserModel`.
   - el schema canónico hereda la forma contractual de `user_model.schema.json`, donde `jwt` es `object`.
   - el `toJson()` actual de `UserModel` sigue serializando `jwt` como string JSON embebido, por lo que esta brecha también afecta los payloads Dart del certificado.
+- `ModelAclPlanAssignment`
+  - embebe `targetUser` y opcionalmente `assignedBy` como `UserModel`.
+  - el schema canónico hereda la forma contractual de `user_model.schema.json`, donde `jwt` es `object`.
+  - el `toJson()` actual de `UserModel` sigue serializando `jwt` como string JSON embebido, por lo que esta brecha también afecta los payloads Dart de asignación ACL.
 
 Estas brechas no se resuelven en esta carpeta. Se documentan aqui para preparar una posterior normalización de mappers Dart sin contaminar el contrato portable.

--- a/doc/schemas/v1/README.md
+++ b/doc/schemas/v1/README.md
@@ -4,8 +4,8 @@ Esta carpeta contiene la primera version de contratos JSON canonicos para `jocaa
 
 Resumen actual de cobertura:
 
-- `71` schemas versionados
-- `71` examples canónicos
+- `73` schemas versionados
+- `73` examples canónicos
 - convención uno a uno entre `foo.schema.json` y `examples/foo.example.json`
 
 ## Modelos incluidos
@@ -60,6 +60,8 @@ Resumen actual de cobertura:
 - `model_learning_goal.schema.json`
 - `model_learning_item.schema.json`
 - `model_acl.schema.json`
+- `model_acl_plan.schema.json`
+- `model_acl_plan_assignment.schema.json`
 - `user_model.schema.json`
 - `person_model.schema.json`
 - `onboarding_state.schema.json`
@@ -108,6 +110,8 @@ Resumen actual de cobertura:
 - `model_item.schema.json` referencia `model_category.schema.json`, `model_price.schema.json` y `attribute_model.schema.json`
 - `model_complete_flow.schema.json` referencia `model_flow_step.schema.json`
 - `model_flow_certificate.schema.json` referencia `model_complete_flow.schema.json`, `model_flow_step_completion.schema.json` y `user_model.schema.json`
+- `model_acl_plan.schema.json` referencia `model_acl.schema.json`
+- `model_acl_plan_assignment.schema.json` referencia `model_acl_plan.schema.json` y `user_model.schema.json`
 - `model_point.schema.json` referencia `model_vector.schema.json`
 - `model_graph.schema.json` referencia `model_graph_axis_spec.schema.json` y `model_point.schema.json`
 - `model_group.schema.json` referencia `model_group_labels.schema.json` y `model_crud_metadata.schema.json`
@@ -159,6 +163,8 @@ Resultado esperado:
 - En contratos de certificación de flujo, `ModelFlowCertificate` embebe el `ModelCompleteFlow` desde el inicio del proceso
 - En contratos de certificación de flujo, `stepCompletionsByIndex` registra trazabilidad mínima secuencial por paso
 - En contratos de certificación de flujo, `state` distingue `draft`, `inProgress`, `readyForCertification` y `certified`
+- En contratos ACL agrupados, `ModelAclPlan` embebe grants `ModelAcl` completos y no una proyección reducida
+- En contratos ACL agrupados, `ModelAclPlanAssignment` embebe el plan completo como snapshot histórico de la asignación
 - En contratos Sheets, `ModelSheetRow` representa un registro persistible mediante `idRow` y `data`
 - En contratos Sheets, `idRow` es la PK efectiva y siempre se serializa como `string`
 - En contratos Sheets, `data` es un objeto JSON gobernado por los nombres únicos declarados en `ModelSheetColumn`
@@ -178,6 +184,7 @@ Resultado esperado:
 - En la familia Docs, el markdown libre se limita a bloques `markdown` y no se modela rich text inline.
 - En la familia IA, la respuesta canónica es única y no se modelan múltiples candidates ni tool calling en `v1`.
 - En la familia Flow Certificate, la certificación es explícita y un estado `certified` implica cierre lógico e inmutabilidad documental del certificado.
+- En la familia ACL Plan, los grants individuales siguen viviendo en `ModelAcl` y el plan solo agrega semántica reusable de bundle y asignación batch.
 - En la familia Sheets no se modelan labels visibles, fórmulas, orden visual, foreign keys ni versionado estructural.
 
 ## Brechas conocidas entre contrato y Dart actual
@@ -215,6 +222,10 @@ Resultado esperado:
   - formalizan el dominio mínimo para certificación lineal auditable de flujos.
   - el flujo vive embebido dentro del certificado y no depende de que siga existiendo una plantilla externa.
   - la certificación final es una acción explícita y no se deduce automáticamente solo por completar pasos.
+- `model_acl_plan.schema.json` y `model_acl_plan_assignment.schema.json`
+  - formalizan el dominio mínimo para bundles ACL reutilizables y su asignación batch auditable.
+  - `ModelAclPlanAssignment` embebe el plan completo para que la asignación siga siendo auditable aunque cambie o desaparezca la plantilla origen.
+  - los payloads Dart siguen heredando la brecha actual de `UserModel.jwt` cuando serializan `targetUser` o `assignedBy`.
 
 ## Compatibilidad esperada
 

--- a/doc/schemas/v1/examples/model_acl_plan.example.json
+++ b/doc/schemas/v1/examples/model_acl_plan.example.json
@@ -1,0 +1,32 @@
+{
+  "id": "acl_plan_bienvenido_operator_v1",
+  "name": "BienvenidoOperatorDefaults",
+  "description": "Default access bundle for regular operators in the Bienvenido app.",
+  "appName": "bienvenido",
+  "acls": [
+    {
+      "id": "acl_bienvenido_dashboard_operator",
+      "roleType": "viewer",
+      "appName": "bienvenido",
+      "feature": "dashboard",
+      "email": "template@jocaagura.dev",
+      "isActive": true,
+      "emailAutorizedBy": "admin@jocaagura.dev",
+      "autorizedAtIsoDate": "2026-03-20T10:00:00.000Z",
+      "revokedAtIsoDate": "2026-12-31T23:59:59.000Z",
+      "note": "Default dashboard access for operator plan."
+    },
+    {
+      "id": "acl_bienvenido_profile_operator",
+      "roleType": "editor",
+      "appName": "bienvenido",
+      "feature": "profile",
+      "email": "template@jocaagura.dev",
+      "isActive": true,
+      "emailAutorizedBy": "admin@jocaagura.dev",
+      "autorizedAtIsoDate": "2026-03-20T10:00:00.000Z",
+      "revokedAtIsoDate": "2026-12-31T23:59:59.000Z",
+      "note": "Default profile update access for operator plan."
+    }
+  ]
+}

--- a/doc/schemas/v1/examples/model_acl_plan_assignment.example.json
+++ b/doc/schemas/v1/examples/model_acl_plan_assignment.example.json
@@ -1,0 +1,57 @@
+{
+  "id": "acl_assignment_bienvenido_operator_001",
+  "plan": {
+    "id": "acl_plan_bienvenido_operator_v1",
+    "name": "BienvenidoOperatorDefaults",
+    "description": "Default access bundle for regular operators in the Bienvenido app.",
+    "appName": "bienvenido",
+    "acls": [
+      {
+        "id": "acl_bienvenido_dashboard_operator",
+        "roleType": "viewer",
+        "appName": "bienvenido",
+        "feature": "dashboard",
+        "email": "template@jocaagura.dev",
+        "isActive": true,
+        "emailAutorizedBy": "admin@jocaagura.dev",
+        "autorizedAtIsoDate": "2026-03-20T10:00:00.000Z",
+        "revokedAtIsoDate": "2026-12-31T23:59:59.000Z",
+        "note": "Default dashboard access for operator plan."
+      },
+      {
+        "id": "acl_bienvenido_profile_operator",
+        "roleType": "editor",
+        "appName": "bienvenido",
+        "feature": "profile",
+        "email": "template@jocaagura.dev",
+        "isActive": true,
+        "emailAutorizedBy": "admin@jocaagura.dev",
+        "autorizedAtIsoDate": "2026-03-20T10:00:00.000Z",
+        "revokedAtIsoDate": "2026-12-31T23:59:59.000Z",
+        "note": "Default profile update access for operator plan."
+      }
+    ]
+  },
+  "targetUser": {
+    "id": "user_201",
+    "displayName": "Camila Operator",
+    "photoUrl": "https://example.com/users/camila.jpg",
+    "email": "camila.operator@example.com",
+    "jwt": {
+      "token": "user-plan-001",
+      "exp": 1773984000
+    }
+  },
+  "assignedAt": "2026-03-20T11:30:00.000Z",
+  "assignedBy": {
+    "id": "user_admin_001",
+    "displayName": "Ana Admin",
+    "photoUrl": "https://example.com/users/ana-admin.jpg",
+    "email": "ana.admin@example.com",
+    "jwt": {
+      "token": "admin-plan-001",
+      "exp": 1773984000
+    }
+  },
+  "notes": "Default operator ACL plan seeded during onboarding."
+}

--- a/doc/schemas/v1/model_acl_plan.schema.json
+++ b/doc/schemas/v1/model_acl_plan.schema.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://jocaagura.dev/schemas/jocaagura_domain/v1/model_acl_plan.schema.json",
+  "title": "ModelAclPlan",
+  "description": "Canonical JSON contract for a reusable ACL plan in jocaagura_domain.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "Unique identifier of the ACL plan."
+    },
+    "name": {
+      "type": "string",
+      "description": "Functional display name of the reusable ACL bundle."
+    },
+    "description": {
+      "type": "string",
+      "description": "Optional human description of the ACL plan."
+    },
+    "appName": {
+      "type": "string",
+      "description": "App namespace shared by all ACL grants embedded in the plan."
+    },
+    "acls": {
+      "type": "array",
+      "description": "Concrete ACL grants that make up the reusable plan snapshot.",
+      "items": {
+        "$ref": "./model_acl.schema.json"
+      }
+    }
+  },
+  "required": [
+    "id",
+    "name",
+    "appName",
+    "acls"
+  ],
+  "examples": [
+    {
+      "id": "acl_plan_bienvenido_operator_v1",
+      "name": "BienvenidoOperatorDefaults",
+      "description": "Default access bundle for regular operators in the Bienvenido app.",
+      "appName": "bienvenido",
+      "acls": [
+        {
+          "id": "acl_bienvenido_dashboard_operator",
+          "roleType": "viewer",
+          "appName": "bienvenido",
+          "feature": "dashboard",
+          "email": "template@jocaagura.dev",
+          "isActive": true,
+          "emailAutorizedBy": "admin@jocaagura.dev",
+          "autorizedAtIsoDate": "2026-03-20T10:00:00.000Z",
+          "revokedAtIsoDate": "2026-12-31T23:59:59.000Z",
+          "note": "Default dashboard access for operator plan."
+        },
+        {
+          "id": "acl_bienvenido_profile_operator",
+          "roleType": "editor",
+          "appName": "bienvenido",
+          "feature": "profile",
+          "email": "template@jocaagura.dev",
+          "isActive": true,
+          "emailAutorizedBy": "admin@jocaagura.dev",
+          "autorizedAtIsoDate": "2026-03-20T10:00:00.000Z",
+          "revokedAtIsoDate": "2026-12-31T23:59:59.000Z",
+          "note": "Default profile update access for operator plan."
+        }
+      ]
+    }
+  ]
+}

--- a/doc/schemas/v1/model_acl_plan_assignment.schema.json
+++ b/doc/schemas/v1/model_acl_plan_assignment.schema.json
@@ -1,0 +1,97 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://jocaagura.dev/schemas/jocaagura_domain/v1/model_acl_plan_assignment.schema.json",
+  "title": "ModelAclPlanAssignment",
+  "description": "Canonical JSON contract for assigning an ACL plan snapshot to a target user in jocaagura_domain.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "Unique identifier of the ACL plan assignment."
+    },
+    "plan": {
+      "$ref": "./model_acl_plan.schema.json"
+    },
+    "targetUser": {
+      "$ref": "./user_model.schema.json"
+    },
+    "assignedAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Timestamp when the plan snapshot was assigned to the target user."
+    },
+    "assignedBy": {
+      "$ref": "./user_model.schema.json"
+    },
+    "notes": {
+      "type": "string",
+      "description": "Optional notes recorded when applying the plan."
+    }
+  },
+  "required": [
+    "id",
+    "plan",
+    "targetUser",
+    "assignedAt"
+  ],
+  "examples": [
+    {
+      "id": "acl_assignment_bienvenido_operator_001",
+      "plan": {
+        "id": "acl_plan_bienvenido_operator_v1",
+        "name": "BienvenidoOperatorDefaults",
+        "description": "Default access bundle for regular operators in the Bienvenido app.",
+        "appName": "bienvenido",
+        "acls": [
+          {
+            "id": "acl_bienvenido_dashboard_operator",
+            "roleType": "viewer",
+            "appName": "bienvenido",
+            "feature": "dashboard",
+            "email": "template@jocaagura.dev",
+            "isActive": true,
+            "emailAutorizedBy": "admin@jocaagura.dev",
+            "autorizedAtIsoDate": "2026-03-20T10:00:00.000Z",
+            "revokedAtIsoDate": "2026-12-31T23:59:59.000Z",
+            "note": "Default dashboard access for operator plan."
+          },
+          {
+            "id": "acl_bienvenido_profile_operator",
+            "roleType": "editor",
+            "appName": "bienvenido",
+            "feature": "profile",
+            "email": "template@jocaagura.dev",
+            "isActive": true,
+            "emailAutorizedBy": "admin@jocaagura.dev",
+            "autorizedAtIsoDate": "2026-03-20T10:00:00.000Z",
+            "revokedAtIsoDate": "2026-12-31T23:59:59.000Z",
+            "note": "Default profile update access for operator plan."
+          }
+        ]
+      },
+      "targetUser": {
+        "id": "user_201",
+        "displayName": "Camila Operator",
+        "photoUrl": "https://example.com/users/camila.jpg",
+        "email": "camila.operator@example.com",
+        "jwt": {
+          "token": "user-plan-001",
+          "exp": 1773984000
+        }
+      },
+      "assignedAt": "2026-03-20T11:30:00.000Z",
+      "assignedBy": {
+        "id": "user_admin_001",
+        "displayName": "Ana Admin",
+        "photoUrl": "https://example.com/users/ana-admin.jpg",
+        "email": "ana.admin@example.com",
+        "jwt": {
+          "token": "admin-plan-001",
+          "exp": 1773984000
+        }
+      },
+      "notes": "Default operator ACL plan seeded during onboarding."
+    }
+  ]
+}

--- a/lib/domain/apps/model_acl_plan.dart
+++ b/lib/domain/apps/model_acl_plan.dart
@@ -1,0 +1,104 @@
+part of 'package:jocaagura_domain/jocaagura_domain.dart';
+
+/// Stable JSON keys used by [ModelAclPlan].
+enum ModelAclPlanEnum {
+  id,
+  name,
+  description,
+  appName,
+  acls,
+}
+
+/// Reusable bundle of concrete ACL grants for a specific app.
+class ModelAclPlan extends Model {
+  const ModelAclPlan({
+    required this.id,
+    required this.name,
+    required this.appName,
+    required this.acls,
+    this.description,
+  });
+
+  factory ModelAclPlan.fromJson(Map<String, dynamic> json) {
+    return ModelAclPlan(
+      id: Utils.getStringFromDynamic(json[ModelAclPlanEnum.id.name]),
+      name: Utils.getStringFromDynamic(json[ModelAclPlanEnum.name.name]),
+      description: json.containsKey(ModelAclPlanEnum.description.name)
+          ? _aclNullableStringFromDynamic(
+              json[ModelAclPlanEnum.description.name],
+            )
+          : null,
+      appName: Utils.getStringFromDynamic(json[ModelAclPlanEnum.appName.name]),
+      acls: Utils.listFromDynamic(json[ModelAclPlanEnum.acls.name])
+          .map((Map<String, dynamic> e) => ModelAcl.fromJson(e))
+          .toList(growable: false),
+    );
+  }
+
+  final String id;
+  final String name;
+  final String? description;
+  final String appName;
+  final List<ModelAcl> acls;
+
+  @override
+  ModelAclPlan copyWith({
+    String? id,
+    String? name,
+    Object? description = _aclPlanUnset,
+    String? appName,
+    List<ModelAcl>? acls,
+  }) {
+    return ModelAclPlan(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      description: identical(description, _aclPlanUnset)
+          ? this.description
+          : description as String?,
+      appName: appName ?? this.appName,
+      acls: acls ?? this.acls,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> json = <String, dynamic>{
+      ModelAclPlanEnum.id.name: id,
+      ModelAclPlanEnum.name.name: name,
+      ModelAclPlanEnum.appName.name: appName,
+      ModelAclPlanEnum.acls.name:
+          acls.map((ModelAcl acl) => acl.toJson()).toList(growable: false),
+    };
+
+    if (description != null) {
+      json[ModelAclPlanEnum.description.name] = description;
+    }
+
+    return json;
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ModelAclPlan &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          name == other.name &&
+          description == other.description &&
+          appName == other.appName &&
+          Utils.listEquals(acls, other.acls);
+
+  @override
+  int get hashCode => Object.hash(
+        id,
+        name,
+        description,
+        appName,
+        Utils.listHash(acls),
+      );
+
+  @override
+  String toString() => 'ModelAclPlan(${toJson()})';
+}
+
+const Object _aclPlanUnset = Object();

--- a/lib/domain/apps/model_acl_plan_assignment.dart
+++ b/lib/domain/apps/model_acl_plan_assignment.dart
@@ -1,0 +1,141 @@
+part of 'package:jocaagura_domain/jocaagura_domain.dart';
+
+/// Stable JSON keys used by [ModelAclPlanAssignment].
+enum ModelAclPlanAssignmentEnum {
+  id,
+  plan,
+  targetUser,
+  assignedAt,
+  assignedBy,
+  notes,
+}
+
+/// Snapshot assignment of an ACL plan to a target user.
+class ModelAclPlanAssignment extends Model {
+  const ModelAclPlanAssignment({
+    required this.id,
+    required this.plan,
+    required this.targetUser,
+    required this.assignedAt,
+    this.assignedBy,
+    this.notes,
+  });
+
+  factory ModelAclPlanAssignment.fromJson(Map<String, dynamic> json) {
+    return ModelAclPlanAssignment(
+      id: Utils.getStringFromDynamic(json[ModelAclPlanAssignmentEnum.id.name]),
+      plan: ModelAclPlan.fromJson(
+        Utils.mapFromDynamic(json[ModelAclPlanAssignmentEnum.plan.name]),
+      ),
+      targetUser: UserModel.fromJson(
+        Utils.mapFromDynamic(json[ModelAclPlanAssignmentEnum.targetUser.name]),
+      ),
+      assignedAt: DateUtils.dateTimeFromDynamic(
+        json[ModelAclPlanAssignmentEnum.assignedAt.name],
+      ),
+      assignedBy: json.containsKey(ModelAclPlanAssignmentEnum.assignedBy.name)
+          ? UserModel.fromJson(
+              Utils.mapFromDynamic(
+                json[ModelAclPlanAssignmentEnum.assignedBy.name],
+              ),
+            )
+          : null,
+      notes: json.containsKey(ModelAclPlanAssignmentEnum.notes.name)
+          ? _aclNullableStringFromDynamic(
+              json[ModelAclPlanAssignmentEnum.notes.name],
+            )
+          : null,
+    );
+  }
+
+  final String id;
+  final ModelAclPlan plan;
+  final UserModel targetUser;
+  final DateTime assignedAt;
+  final UserModel? assignedBy;
+  final String? notes;
+
+  @override
+  ModelAclPlanAssignment copyWith({
+    String? id,
+    ModelAclPlan? plan,
+    UserModel? targetUser,
+    DateTime? assignedAt,
+    Object? assignedBy = _aclPlanAssignmentUnset,
+    Object? notes = _aclPlanAssignmentUnset,
+  }) {
+    return ModelAclPlanAssignment(
+      id: id ?? this.id,
+      plan: plan ?? this.plan,
+      targetUser: targetUser ?? this.targetUser,
+      assignedAt: assignedAt ?? this.assignedAt,
+      assignedBy: identical(assignedBy, _aclPlanAssignmentUnset)
+          ? this.assignedBy
+          : assignedBy as UserModel?,
+      notes: identical(notes, _aclPlanAssignmentUnset)
+          ? this.notes
+          : notes as String?,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> json = <String, dynamic>{
+      ModelAclPlanAssignmentEnum.id.name: id,
+      ModelAclPlanAssignmentEnum.plan.name: plan.toJson(),
+      ModelAclPlanAssignmentEnum.targetUser.name: targetUser.toJson(),
+      ModelAclPlanAssignmentEnum.assignedAt.name:
+          DateUtils.dateTimeToString(assignedAt),
+    };
+
+    if (assignedBy != null) {
+      json[ModelAclPlanAssignmentEnum.assignedBy.name] = assignedBy!.toJson();
+    }
+    if (notes != null) {
+      json[ModelAclPlanAssignmentEnum.notes.name] = notes;
+    }
+
+    return json;
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ModelAclPlanAssignment &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          plan == other.plan &&
+          Utils.deepEqualsDynamic(
+            targetUser.toJson(),
+            other.targetUser.toJson(),
+          ) &&
+          assignedAt == other.assignedAt &&
+          Utils.deepEqualsDynamic(
+            assignedBy?.toJson(),
+            other.assignedBy?.toJson(),
+          ) &&
+          notes == other.notes;
+
+  @override
+  int get hashCode => Object.hash(
+        id,
+        plan,
+        Utils.deepHash(targetUser.toJson()),
+        assignedAt,
+        Utils.deepHash(assignedBy?.toJson()),
+        notes,
+      );
+
+  @override
+  String toString() => 'ModelAclPlanAssignment(${toJson()})';
+}
+
+const Object _aclPlanAssignmentUnset = Object();
+
+String? _aclNullableStringFromDynamic(dynamic value) {
+  if (value == null) {
+    return null;
+  }
+  final String parsed = Utils.getStringFromDynamic(value);
+  return parsed.isEmpty ? null : parsed;
+}

--- a/lib/jocaagura_domain.dart
+++ b/lib/jocaagura_domain.dart
@@ -39,6 +39,8 @@ part 'domain/ai/model_ai_message.dart';
 part 'domain/ai/model_ai_request.dart';
 part 'domain/ai/model_ai_response.dart';
 part 'domain/apps/model_acl.dart';
+part 'domain/apps/model_acl_plan.dart';
+part 'domain/apps/model_acl_plan_assignment.dart';
 part 'domain/apps/model_acl_policy.dart';
 part 'domain/apps/model_app_version.dart';
 part 'domain/attribute_model.dart';

--- a/test/domain/acl_model_plan_assignment_test.dart
+++ b/test/domain/acl_model_plan_assignment_test.dart
@@ -1,0 +1,101 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jocaagura_domain/jocaagura_domain.dart';
+
+void main() {
+  group('ModelAclPlanAssignment', () {
+    const ModelAclPlan plan = ModelAclPlan(
+      id: 'acl_plan_bienvenido_operator_v1',
+      name: 'BienvenidoOperatorDefaults',
+      description:
+          'Default access bundle for regular operators in the Bienvenido app.',
+      appName: 'bienvenido',
+      acls: <ModelAcl>[
+        ModelAcl(
+          id: 'acl_bienvenido_dashboard_operator',
+          roleType: RoleType.viewer,
+          appName: 'bienvenido',
+          feature: 'dashboard',
+          email: 'template@jocaagura.dev',
+          isActive: true,
+          emailAutorizedBy: 'admin@jocaagura.dev',
+          autorizedAtIsoDate: '2026-03-20T10:00:00.000Z',
+          note: 'Default dashboard access for operator plan.',
+        ),
+        ModelAcl(
+          id: 'acl_bienvenido_profile_operator',
+          roleType: RoleType.editor,
+          appName: 'bienvenido',
+          feature: 'profile',
+          email: 'template@jocaagura.dev',
+          isActive: true,
+          emailAutorizedBy: 'admin@jocaagura.dev',
+          autorizedAtIsoDate: '2026-03-20T10:00:00.000Z',
+          note: 'Default profile update access for operator plan.',
+        ),
+      ],
+    );
+
+    const UserModel targetUser = UserModel(
+      id: 'user_201',
+      displayName: 'Camila Operator',
+      photoUrl: 'https://example.com/users/camila.jpg',
+      email: 'camila.operator@example.com',
+      jwt: <String, dynamic>{'token': 'user-plan-001', 'exp': 1773984000},
+    );
+
+    const UserModel assignedBy = UserModel(
+      id: 'user_admin_001',
+      displayName: 'Ana Admin',
+      photoUrl: 'https://example.com/users/ana-admin.jpg',
+      email: 'ana.admin@example.com',
+      jwt: <String, dynamic>{'token': 'admin-plan-001', 'exp': 1773984000},
+    );
+
+    final ModelAclPlanAssignment assignment = ModelAclPlanAssignment(
+      id: 'acl_assignment_bienvenido_operator_001',
+      plan: plan,
+      targetUser: targetUser,
+      assignedAt: DateTime.utc(2026, 3, 20, 11, 30),
+      assignedBy: assignedBy,
+      notes: 'Default operator ACL plan seeded during onboarding.',
+    );
+
+    test(
+      'Given a canonical ACL plan assignment When toJson and fromJson Then preserves the contract',
+      () {
+        final Map<String, dynamic> json = assignment.toJson();
+        final ModelAclPlanAssignment roundtrip =
+            ModelAclPlanAssignment.fromJson(json);
+
+        expect(roundtrip, assignment);
+        expect(roundtrip.toJson(), assignment.toJson());
+      },
+    );
+
+    test(
+      'Given current Dart JSON When fromJson and toJson Then preserves JSON roundtrip',
+      () {
+        final Map<String, dynamic> json = assignment.toJson();
+
+        final ModelAclPlanAssignment parsed =
+            ModelAclPlanAssignment.fromJson(json);
+
+        expect(parsed.toJson(), json);
+      },
+    );
+
+    test(
+      'Given an ACL plan assignment When copyWith overrides fields Then returns updated copy',
+      () {
+        final ModelAclPlanAssignment copy = assignment.copyWith(
+          notes: null,
+          assignedBy: null,
+        );
+
+        expect(copy.notes, isNull);
+        expect(copy.assignedBy, isNull);
+        expect(copy, isNot(assignment));
+      },
+    );
+  });
+}

--- a/test/domain/acl_model_plan_test.dart
+++ b/test/domain/acl_model_plan_test.dart
@@ -1,0 +1,74 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jocaagura_domain/jocaagura_domain.dart';
+
+void main() {
+  group('ModelAclPlan', () {
+    const ModelAclPlan plan = ModelAclPlan(
+      id: 'acl_plan_bienvenido_operator_v1',
+      name: 'BienvenidoOperatorDefaults',
+      description:
+          'Default access bundle for regular operators in the Bienvenido app.',
+      appName: 'bienvenido',
+      acls: <ModelAcl>[
+        ModelAcl(
+          id: 'acl_bienvenido_dashboard_operator',
+          roleType: RoleType.viewer,
+          appName: 'bienvenido',
+          feature: 'dashboard',
+          email: 'template@jocaagura.dev',
+          isActive: true,
+          emailAutorizedBy: 'admin@jocaagura.dev',
+          autorizedAtIsoDate: '2026-03-20T10:00:00.000Z',
+          note: 'Default dashboard access for operator plan.',
+        ),
+        ModelAcl(
+          id: 'acl_bienvenido_profile_operator',
+          roleType: RoleType.editor,
+          appName: 'bienvenido',
+          feature: 'profile',
+          email: 'template@jocaagura.dev',
+          isActive: true,
+          emailAutorizedBy: 'admin@jocaagura.dev',
+          autorizedAtIsoDate: '2026-03-20T10:00:00.000Z',
+          note: 'Default profile update access for operator plan.',
+        ),
+      ],
+    );
+
+    test(
+      'Given a canonical ACL plan When toJson and fromJson Then preserves the contract',
+      () {
+        final Map<String, dynamic> json = plan.toJson();
+        final ModelAclPlan roundtrip = ModelAclPlan.fromJson(json);
+
+        expect(roundtrip, plan);
+        expect(roundtrip.toJson(), plan.toJson());
+      },
+    );
+
+    test(
+      'Given canonical JSON When fromJson and toJson Then preserves JSON roundtrip',
+      () {
+        final Map<String, dynamic> json = plan.toJson();
+
+        final ModelAclPlan parsed = ModelAclPlan.fromJson(json);
+
+        expect(parsed.toJson(), json);
+      },
+    );
+
+    test(
+      'Given an ACL plan When copyWith overrides fields Then returns updated copy',
+      () {
+        final ModelAclPlan copy = plan.copyWith(
+          name: 'BienvenidoEditors',
+          description: null,
+        );
+
+        expect(copy.name, 'BienvenidoEditors');
+        expect(copy.description, isNull);
+        expect(copy, isNot(plan));
+      },
+    );
+  });
+}


### PR DESCRIPTION
## [1.39.2] - 2026-03-20

### Added
- **ACL plan domain module**
  - Nuevos modelos reutilizables para agrupación funcional de ACLs:
    - `ModelAclPlan`
    - `ModelAclPlanAssignment`
  - `ModelAclPlan` define bundles de grants concretos reutilizando `ModelAcl` completo.
  - `ModelAclPlanAssignment` conserva el plan completo embebido como snapshot histórico de asignación a usuario.
- **ACL plan unit tests**
  - Nuevas pruebas unitarias para:
    - roundtrip `fromJson(toJson(model))`
    - roundtrip `toJson(fromJson(jsonCanonico))`
    - `copyWith`
  - Cobertura inicial para:
    - `acl_model_plan_test.dart`
    - `acl_model_plan_assignment_test.dart`
- **ACL plan JSON contracts**
  - Nuevos schemas y examples canónicos en `doc/schemas/v1/` para:
    - `model_acl_plan.schema.json`
    - `model_acl_plan_assignment.schema.json`
  - Se formaliza:
    - agrupación ACL reusable como plan funcional
    - asignación batch auditable mediante snapshot embebido
    - reutilización explícita de `ModelAcl` y `UserModel`

### Changed
- **ACL schema documentation**
  - Se actualizan `doc/schemas/README.md` y `doc/schemas/v1/README.md` para reflejar:
    - la diferencia entre grant individual, política, plan y asignación
    - el uso de snapshots embebidos en `ModelAclPlanAssignment`
    - la brecha heredada de `UserModel.jwt` cuando una asignación serializa `targetUser` o `assignedBy`
- **Branch work plan**
  - Se reemplaza `plan-de-trabajo.md` con el plan de ejecución cerrado para la fase ACL Plan.
