### PR TITLE
Rev/create transversal modelvehicle with json roundtrip and canonical json schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Recent entries aim to follow a normalized structure. Older historical entries may preserve some original headings where reclassification would risk changing the original intent.
 
+## [1.39.4] - 2026-04-01
+
+### Added
+- **Vehicle base domain contract**
+  - Nuevo módulo vehicular base con:
+    - `ModelVehicle`
+    - `ModelVehicleEnum`
+  - `ModelVehicle` define un contrato transversal mínimo y reusable con:
+    - identidad estructural (`id`, `displayName`, `plate`)
+    - datos base (`brand`, `model`, `year`, `description`, `isActive`)
+    - clasificación principal mediante `ModelCategory`
+    - clasificación secundaria mediante `List<ModelCategory>`
+    - extensibilidad operativa mediante `Map<String, AttributeModel<dynamic>>`
+- **Vehicle unit tests**
+  - Nuevas pruebas unitarias para `ModelVehicle` cubriendo:
+    - roundtrip JSON canónico
+    - `copyWith`
+    - igualdad y `hashCode`
+    - defaults
+    - normalización defensiva de `attributes`
+- **Vehicle JSON contracts**
+  - Nuevos contratos y examples canónicos en `doc/schemas/v1/` para:
+    - `model_vehicle.schema.json`
+    - `examples/model_vehicle.example.json`
+
+### Changed
+- **Vehicle serialization semantics**
+  - `ModelVehicle.toJson()` fija el shape canónico portable del vehículo.
+  - `ModelVehicle.fromJson()` acepta variantes razonables para `attributes` y converge al contrato canonizado.
+  - La igualdad y el hash de `attributes` se alinean con el contenido serializado para evitar falsas diferencias por genéricos Dart internos.
+- **Schema documentation**
+  - Se actualizan `doc/schemas/README.md` y `doc/schemas/v1/README.md` para reflejar:
+    - la incorporación del contrato vehicular base
+    - la reutilización de `ModelCategory` para clasificación
+    - la reutilización de `AttributeModel` para extensibilidad controlada
+- **Library exports**
+  - Se registran los nuevos `part` del módulo vehicular en `lib/jocaagura_domain.dart`.
+
+### Notes
+- Esta fase cierra únicamente `ModelVehicle Base Contract v1`.
+- La evolución hacia submodelos específicos de documentos, mantenimiento, energía o capacidad queda deliberadamente fuera de esta versión.
+
 ## [1.39.3] - 2026-03-30
 
 ### Added

--- a/doc/schemas/README.md
+++ b/doc/schemas/README.md
@@ -106,6 +106,7 @@ npm run validate:schemas
 - En contratos de certificación de flujo, la certificación final es explícita, no automática, y un estado `certified` implica cierre lógico del proceso.
 - El dominio ACL agrupado introduce `ModelAclPlan` como bundle reusable de grants y `ModelAclPlanAssignment` como snapshot auditable de asignación a usuario.
 - El dominio de Design System publica contratos JSON persistibles y portables, mientras `jocaaguraarchetype` permanece como adaptador Flutter/Material de consumo.
+- El dominio vehicular fija `ModelVehicle` como contrato base transversal y reutiliza `ModelCategory` para clasificación y `AttributeModel` para extensibilidad operativa.
 
 ## Brechas conocidas con la implementación Dart
 

--- a/doc/schemas/v1/README.md
+++ b/doc/schemas/v1/README.md
@@ -4,8 +4,8 @@ Esta carpeta contiene la primera version de contratos JSON canonicos para `jocaa
 
 Resumen actual de cobertura:
 
-- `79` schemas versionados
-- `79` examples canónicos
+- `80` schemas versionados
+- `80` examples canónicos
 - convención uno a uno entre `foo.schema.json` y `examples/foo.example.json`
 
 ## Modelos incluidos
@@ -73,6 +73,7 @@ Resumen actual de cobertura:
 - `onboarding_state.schema.json`
 - `signature_model.schema.json`
 - `model_vector.schema.json`
+- `model_vehicle.schema.json`
 - `store_model.schema.json`
 - `treatment_plan_model.schema.json`
 - `model_category.schema.json`
@@ -113,6 +114,7 @@ Resumen actual de cobertura:
 - `model_learning_item.schema.json` referencia `attribute_model.schema.json`, `model_performance_indicator.schema.json` y `model_category.schema.json`
 - `model_assessment.schema.json` referencia `model_learning_item.schema.json`
 - `person_model.schema.json` referencia `attribute_model.schema.json`
+- `model_vehicle.schema.json` referencia `model_category.schema.json` y `attribute_model.schema.json`
 - `model_item.schema.json` referencia `model_category.schema.json`, `model_price.schema.json` y `attribute_model.schema.json`
 - `model_complete_flow.schema.json` referencia `model_flow_step.schema.json`
 - `model_flow_certificate.schema.json` referencia `model_complete_flow.schema.json`, `model_flow_step_completion.schema.json` y `user_model.schema.json`

--- a/doc/schemas/v1/examples/model_vehicle.example.json
+++ b/doc/schemas/v1/examples/model_vehicle.example.json
@@ -1,0 +1,38 @@
+{
+  "id": "vehicle-001",
+  "displayName": "Van 01",
+  "plate": "ABC123",
+  "brand": "Renault",
+  "model": "Kangoo",
+  "year": 2024,
+  "description": "Urban delivery van",
+  "isActive": true,
+  "vehicleCategory": {
+    "category": "cargo-van",
+    "description": "Light cargo vehicle"
+  },
+  "tags": [
+    {
+      "category": "fleet-a",
+      "description": "Primary fleet"
+    },
+    {
+      "category": "urban-route",
+      "description": "Urban operation"
+    }
+  ],
+  "attributes": {
+    "color": {
+      "name": "color",
+      "value": "white"
+    },
+    "passengerCapacity": {
+      "name": "passengerCapacity",
+      "value": 2
+    },
+    "currentOccupancy": {
+      "name": "currentOccupancy",
+      "value": 1
+    }
+  }
+}

--- a/doc/schemas/v1/model_vehicle.schema.json
+++ b/doc/schemas/v1/model_vehicle.schema.json
@@ -1,0 +1,109 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://jocaagura.dev/schemas/jocaagura_domain/v1/model_vehicle.schema.json",
+  "title": "ModelVehicle",
+  "description": "Canonical JSON contract for ModelVehicle in jocaagura_domain.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "Stable identifier of the vehicle."
+    },
+    "displayName": {
+      "type": "string",
+      "description": "Human-readable vehicle label."
+    },
+    "plate": {
+      "type": "string",
+      "description": "Vehicle plate or registration identifier."
+    },
+    "brand": {
+      "type": "string",
+      "description": "Manufacturer or brand."
+    },
+    "model": {
+      "type": "string",
+      "description": "Vehicle model name."
+    },
+    "year": {
+      "type": "integer",
+      "description": "Vehicle model year."
+    },
+    "description": {
+      "type": "string",
+      "description": "Additional vehicle description."
+    },
+    "isActive": {
+      "type": "boolean",
+      "description": "Whether the vehicle is currently active in the domain."
+    },
+    "vehicleCategory": {
+      "$ref": "./model_category.schema.json",
+      "description": "Primary reusable classification of the vehicle."
+    },
+    "tags": {
+      "type": "array",
+      "description": "Secondary reusable classifications for filtering and grouping.",
+      "items": {
+        "$ref": "./model_category.schema.json"
+      }
+    },
+    "attributes": {
+      "type": "object",
+      "description": "Named dictionary of extensible operational attributes.",
+      "additionalProperties": {
+        "$ref": "./attribute_model.schema.json"
+      }
+    }
+  },
+  "required": [
+    "id",
+    "displayName",
+    "plate",
+    "brand",
+    "model",
+    "year",
+    "description",
+    "isActive",
+    "vehicleCategory",
+    "tags",
+    "attributes"
+  ],
+  "examples": [
+    {
+      "id": "vehicle-001",
+      "displayName": "Van 01",
+      "plate": "ABC123",
+      "brand": "Renault",
+      "model": "Kangoo",
+      "year": 2024,
+      "description": "Urban delivery van",
+      "isActive": true,
+      "vehicleCategory": {
+        "category": "cargo-van",
+        "description": "Light cargo vehicle"
+      },
+      "tags": [
+        {
+          "category": "fleet-a",
+          "description": "Primary fleet"
+        },
+        {
+          "category": "urban-route",
+          "description": "Urban operation"
+        }
+      ],
+      "attributes": {
+        "color": {
+          "name": "color",
+          "value": "white"
+        },
+        "passengerCapacity": {
+          "name": "passengerCapacity",
+          "value": 2
+        }
+      }
+    }
+  ]
+}

--- a/lib/domain/vehicles/model_vehicle.dart
+++ b/lib/domain/vehicles/model_vehicle.dart
@@ -1,0 +1,377 @@
+part of 'package:jocaagura_domain/jocaagura_domain.dart';
+
+/// JSON keys used by [ModelVehicle].
+enum ModelVehicleEnum {
+  id,
+  displayName,
+  plate,
+  brand,
+  model,
+  year,
+  description,
+  isActive,
+  vehicleCategory,
+  tags,
+  attributes,
+}
+
+/// Default instance of [ModelVehicle] for tests and fallback scenarios.
+const ModelVehicle defaultModelVehicle = ModelVehicle(
+  id: '',
+  displayName: 'Default Vehicle',
+  plate: '',
+  brand: '',
+  model: '',
+  year: 0,
+  description: '',
+  isActive: true,
+  vehicleCategory: defaultModelCategory,
+);
+
+/// Represent a canonical cross-cutting vehicle contract for the domain.
+///
+/// This model stores the structural identity of a vehicle and keeps
+/// operational variability in [attributes].
+///
+/// Canonical JSON contract:
+/// - `vehicleCategory` is serialized as a single [ModelCategory].
+/// - `tags` is serialized as an ordered list of [ModelCategory].
+/// - `attributes` is serialized as a named dictionary of [AttributeModel].
+///
+/// The [fromJson] factory is defensive and accepts some non-canonical shapes
+/// to simplify interoperability. However, [toJson] always emits the canonical
+/// portable representation.
+///
+/// Functional example:
+/// ```dart
+/// void main() {
+///   final ModelVehicle vehicle = ModelVehicle(
+///     id: 'vehicle-1',
+///     displayName: 'Delivery Van',
+///     plate: 'ABC123',
+///     brand: 'Jocaagura Motors',
+///     model: 'Cargo X',
+///     year: 2024,
+///     description: 'Main distribution vehicle',
+///     isActive: true,
+///     vehicleCategory: defaultModelCategory,
+///     tags: <ModelCategory>[defaultModelCategory],
+///     attributes: <String, AttributeModel<dynamic>>{
+///       'fuelLevel': AttributeModel<double>(
+///         name: 'fuelLevel',
+///         value: 0.75,
+///       ),
+///     },
+///   );
+///
+///   final Map<String, dynamic> json = vehicle.toJson();
+///   final ModelVehicle parsed = ModelVehicle.fromJson(json);
+///
+///   print(parsed.displayName);
+/// }
+/// ```
+///
+/// Notes:
+/// - [attributes] can represent operational values such as fuel level,
+///   maintenance indicators, attached documents, or occupancy metadata.
+/// - [fromJson] may ignore unsupported attribute values when normalizing
+///   non-canonical input.
+/// - [tags] preserve order during serialization.
+/// - [attributes] are compared by deep JSON content for equality.
+///
+/// Contracts:
+/// - [id], [displayName], [plate], [brand], [model], and [description]
+///   are normalized as strings.
+/// - [year] is normalized as an integer.
+/// - [isActive] defaults to `true` when omitted or null during parsing.
+/// - [vehicleCategory] is always expected as a single category object in the
+///   canonical JSON representation.
+class ModelVehicle extends Model {
+  /// Create an immutable [ModelVehicle].
+  ///
+  /// Use this constructor to define the canonical structural data of a vehicle.
+  ///
+  /// Parameters:
+  /// - [id]: Stable identifier of the vehicle.
+  /// - [displayName]: Human-readable label.
+  /// - [plate]: Registration or plate identifier.
+  /// - [brand]: Manufacturer or brand.
+  /// - [model]: Commercial or internal model name.
+  /// - [year]: Model year.
+  /// - [description]: Additional free-text description.
+  /// - [isActive]: Whether the vehicle is active in the domain.
+  /// - [vehicleCategory]: Primary reusable classification.
+  /// - [tags]: Secondary reusable categories for grouping or filtering.
+  /// - [attributes]: Extensible operational attributes keyed by name.
+  const ModelVehicle({
+    required this.id,
+    required this.displayName,
+    required this.plate,
+    required this.brand,
+    required this.model,
+    required this.year,
+    required this.description,
+    required this.isActive,
+    required this.vehicleCategory,
+    this.tags = const <ModelCategory>[],
+    this.attributes = const <String, AttributeModel<dynamic>>{},
+  });
+
+  /// Create a [ModelVehicle] from a JSON-like map.
+  ///
+  /// This factory accepts the canonical JSON representation and also supports
+  /// some defensive normalization for `attributes`.
+  ///
+  /// Supported `attributes` input shapes:
+  /// - a canonical named map of attribute objects
+  /// - a map of primitive compatible values
+  /// - a list of shallow attribute objects
+  ///
+  /// Returns a normalized immutable [ModelVehicle].
+  ///
+  /// Notes:
+  /// - Missing or null `isActive` values default to `true`.
+  /// - Unsupported attribute values may be ignored during normalization.
+  factory ModelVehicle.fromJson(Map<String, dynamic> json) {
+    return ModelVehicle(
+      id: Utils.getStringFromDynamic(json[ModelVehicleEnum.id.name]),
+      displayName:
+          Utils.getStringFromDynamic(json[ModelVehicleEnum.displayName.name]),
+      plate: Utils.getStringFromDynamic(json[ModelVehicleEnum.plate.name]),
+      brand: Utils.getStringFromDynamic(json[ModelVehicleEnum.brand.name]),
+      model: Utils.getStringFromDynamic(json[ModelVehicleEnum.model.name]),
+      year: Utils.getIntegerFromDynamic(json[ModelVehicleEnum.year.name]),
+      description:
+          Utils.getStringFromDynamic(json[ModelVehicleEnum.description.name]),
+      isActive: Utils.getBoolFromDynamic(
+        json[ModelVehicleEnum.isActive.name],
+        defaultValueIfNull: true,
+      ),
+      vehicleCategory: ModelCategory.fromJson(
+        Utils.mapFromDynamic(json[ModelVehicleEnum.vehicleCategory.name]),
+      ),
+      tags: _tagsFromDynamic(json[ModelVehicleEnum.tags.name]),
+      attributes:
+          _attributesFromDynamic(json[ModelVehicleEnum.attributes.name]),
+    );
+  }
+
+  /// Stable identifier of the vehicle.
+  final String id;
+
+  /// Human-readable display label.
+  final String displayName;
+
+  /// Vehicle plate or registration identifier.
+  final String plate;
+
+  /// Manufacturer or brand.
+  final String brand;
+
+  /// Commercial or internal model name.
+  final String model;
+
+  /// Model year.
+  final int year;
+
+  /// Additional free-text description.
+  final String description;
+
+  /// Whether the vehicle is active in the domain.
+  final bool isActive;
+
+  /// Primary reusable classification of the vehicle.
+  final ModelCategory vehicleCategory;
+
+  /// Secondary reusable tags for grouping or filtering.
+  final List<ModelCategory> tags;
+
+  /// Named extensible attributes for operational context.
+  final Map<String, AttributeModel<dynamic>> attributes;
+
+  /// Create a copy of this vehicle with the provided overrides.
+  ///
+  /// Any parameter left as `null` preserves the current value.
+  ///
+  /// Returns a new [ModelVehicle] instance.
+  @override
+  ModelVehicle copyWith({
+    String? id,
+    String? displayName,
+    String? plate,
+    String? brand,
+    String? model,
+    int? year,
+    String? description,
+    bool? isActive,
+    ModelCategory? vehicleCategory,
+    List<ModelCategory>? tags,
+    Map<String, AttributeModel<dynamic>>? attributes,
+  }) {
+    return ModelVehicle(
+      id: id ?? this.id,
+      displayName: displayName ?? this.displayName,
+      plate: plate ?? this.plate,
+      brand: brand ?? this.brand,
+      model: model ?? this.model,
+      year: year ?? this.year,
+      description: description ?? this.description,
+      isActive: isActive ?? this.isActive,
+      vehicleCategory: vehicleCategory ?? this.vehicleCategory,
+      tags: tags ?? this.tags,
+      attributes: attributes ?? this.attributes,
+    );
+  }
+
+  /// Serialize this vehicle into its canonical JSON representation.
+  ///
+  /// Returns a portable map where:
+  /// - `vehicleCategory` is a single serialized [ModelCategory]
+  /// - `tags` is an ordered list of serialized [ModelCategory]
+  /// - `attributes` is a named map of serialized [AttributeModel]
+  @override
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> serializedAttributes = <String, dynamic>{};
+    for (final MapEntry<String, AttributeModel<dynamic>> entry
+        in attributes.entries) {
+      serializedAttributes[entry.key] = entry.value.toJson();
+    }
+
+    return <String, dynamic>{
+      ModelVehicleEnum.id.name: id,
+      ModelVehicleEnum.displayName.name: displayName,
+      ModelVehicleEnum.plate.name: plate,
+      ModelVehicleEnum.brand.name: brand,
+      ModelVehicleEnum.model.name: model,
+      ModelVehicleEnum.year.name: year,
+      ModelVehicleEnum.description.name: description,
+      ModelVehicleEnum.isActive.name: isActive,
+      ModelVehicleEnum.vehicleCategory.name: vehicleCategory.toJson(),
+      ModelVehicleEnum.tags.name:
+          tags.map((ModelCategory tag) => tag.toJson()).toList(),
+      ModelVehicleEnum.attributes.name: serializedAttributes,
+    };
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        other is ModelVehicle &&
+            runtimeType == other.runtimeType &&
+            other.id == id &&
+            other.displayName == displayName &&
+            other.plate == plate &&
+            other.brand == brand &&
+            other.model == model &&
+            other.year == year &&
+            other.description == description &&
+            other.isActive == isActive &&
+            other.vehicleCategory == vehicleCategory &&
+            Utils.listEquals(other.tags, tags) &&
+            _attributeMapEquals(other.attributes, attributes);
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        id,
+        displayName,
+        plate,
+        brand,
+        model,
+        year,
+        description,
+        isActive,
+        vehicleCategory,
+        Utils.listHash(tags),
+        _attributeMapHash(attributes),
+      );
+
+  @override
+  String toString() => 'ModelVehicle(${toJson()})';
+
+  static List<ModelCategory> _tagsFromDynamic(dynamic rawTags) {
+    return Utils.listFromDynamic(rawTags)
+        .map(ModelCategory.fromJson)
+        .toList(growable: false);
+  }
+
+  static Map<String, AttributeModel<dynamic>> _attributesFromDynamic(
+    dynamic rawAttributes,
+  ) {
+    if (rawAttributes is List) {
+      final List<ModelAttribute<dynamic>> list =
+          AttributeModel.listFromDynamicShallow(rawAttributes);
+      final Map<String, AttributeModel<dynamic>> fromList =
+          <String, AttributeModel<dynamic>>{};
+      for (final AttributeModel<dynamic> attribute in list) {
+        if (attribute.name.isNotEmpty) {
+          fromList[attribute.name] = attribute;
+        }
+      }
+      return Map<String, AttributeModel<dynamic>>.unmodifiable(fromList);
+    }
+
+    final Map<String, dynamic> rawMap = Utils.mapFromDynamic(rawAttributes);
+    final Map<String, AttributeModel<dynamic>> parsed =
+        <String, AttributeModel<dynamic>>{};
+
+    for (final MapEntry<String, dynamic> entry in rawMap.entries) {
+      final String key = entry.key;
+      final dynamic value = entry.value;
+
+      if (value is Map) {
+        final Map<String, dynamic> mapValue = Utils.mapFromDynamic(value);
+        final String attributeName =
+            Utils.getStringFromDynamic(mapValue[AttributeEnum.name.name])
+                    .isEmpty
+                ? key
+                : Utils.getStringFromDynamic(mapValue[AttributeEnum.name.name]);
+        final dynamic attributeValue = mapValue[AttributeEnum.value.name];
+        if (AttributeModel.isDomainCompatible(attributeValue)) {
+          parsed[key] = AttributeModel<dynamic>(
+            name: attributeName,
+            value: attributeValue,
+          );
+        }
+        continue;
+      }
+
+      if (AttributeModel.isDomainCompatible(value)) {
+        parsed[key] = AttributeModel<dynamic>(name: key, value: value);
+      }
+    }
+
+    return Map<String, AttributeModel<dynamic>>.unmodifiable(parsed);
+  }
+
+  static bool _attributeMapEquals(
+    Map<String, AttributeModel<dynamic>> a,
+    Map<String, AttributeModel<dynamic>> b,
+  ) {
+    if (identical(a, b)) {
+      return true;
+    }
+    if (a.length != b.length) {
+      return false;
+    }
+    for (final MapEntry<String, AttributeModel<dynamic>> entry in a.entries) {
+      final AttributeModel<dynamic>? otherValue = b[entry.key];
+      if (otherValue == null) {
+        return false;
+      }
+      if (!Utils.deepEqualsMap(entry.value.toJson(), otherValue.toJson())) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  static int _attributeMapHash(Map<String, AttributeModel<dynamic>> map) {
+    return Object.hashAllUnordered(
+      map.entries.map(
+        (MapEntry<String, AttributeModel<dynamic>> entry) =>
+            Object.hash(entry.key, Utils.deepHash(entry.value.toJson())),
+      ),
+    );
+  }
+}

--- a/lib/jocaagura_domain.dart
+++ b/lib/jocaagura_domain.dart
@@ -177,6 +177,7 @@ part 'domain/usecases/session/watch_auth_state_changes_usecases.dart';
 part 'domain/usecases/usecase.dart';
 part 'domain/user_model.dart';
 part 'domain/utils/money_utils.dart';
+part 'domain/vehicles/model_vehicle.dart';
 part 'per_key_fifo_executor.dart';
 part 'unit.dart';
 part 'utils.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: jocaagura_domain
 description: "A package with domain models for all transversal applications"
 
-version: 1.39.3
+version: 1.39.4
 
 homepage: https://github.com/jocaagura/jocaagura_domain
 repository: https://github.com/jocaagura/jocaagura_domain

--- a/test/domain/vehicles/model_vehicle_test.dart
+++ b/test/domain/vehicles/model_vehicle_test.dart
@@ -1,0 +1,348 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jocaagura_domain/jocaagura_domain.dart';
+
+void main() {
+  group('ModelVehicle', () {
+    const ModelCategory vehicleCategory = ModelCategory(
+      category: 'Cargo Van',
+      description: 'Light cargo vehicle',
+    );
+    const ModelCategory fleetTag = ModelCategory(
+      category: 'Fleet A',
+      description: 'Primary fleet',
+    );
+    const ModelCategory urbanTag = ModelCategory(
+      category: 'Urban Route',
+      description: 'Urban operation',
+    );
+    const AttributeModel<String> colorAttribute = AttributeModel<String>(
+      name: 'color',
+      value: 'white',
+    );
+    const AttributeModel<int> passengerAttribute = AttributeModel<int>(
+      name: 'passengerCapacity',
+      value: 2,
+    );
+
+    const ModelVehicle model = ModelVehicle(
+      id: 'vehicle-001',
+      displayName: 'Van 01',
+      plate: 'ABC123',
+      brand: 'Renault',
+      model: 'Kangoo',
+      year: 2024,
+      description: 'Urban delivery van',
+      isActive: true,
+      vehicleCategory: vehicleCategory,
+      tags: <ModelCategory>[
+        fleetTag,
+        urbanTag,
+      ],
+      attributes: <String, AttributeModel<dynamic>>{
+        'color': colorAttribute,
+        'passengerCapacity': passengerAttribute,
+      },
+    );
+
+    test(
+      'Given canonical payload When fromJson then reconstructs the full model',
+      () {
+        final Map<String, dynamic> json = <String, dynamic>{
+          ModelVehicleEnum.id.name: 'vehicle-001',
+          ModelVehicleEnum.displayName.name: 'Van 01',
+          ModelVehicleEnum.plate.name: 'ABC123',
+          ModelVehicleEnum.brand.name: 'Renault',
+          ModelVehicleEnum.model.name: 'Kangoo',
+          ModelVehicleEnum.year.name: 2024,
+          ModelVehicleEnum.description.name: 'Urban delivery van',
+          ModelVehicleEnum.isActive.name: true,
+          ModelVehicleEnum.vehicleCategory.name: vehicleCategory.toJson(),
+          ModelVehicleEnum.tags.name: <Map<String, dynamic>>[
+            fleetTag.toJson(),
+            urbanTag.toJson(),
+          ],
+          ModelVehicleEnum.attributes.name: <String, dynamic>{
+            'color': colorAttribute.toJson(),
+            'passengerCapacity': passengerAttribute.toJson(),
+          },
+        };
+
+        final ModelVehicle parsed = ModelVehicle.fromJson(json);
+
+        expect(parsed, equals(model));
+        expect(
+          parsed.attributes['color']?.toJson(),
+          equals(colorAttribute.toJson()),
+        );
+        expect(
+          parsed.attributes['passengerCapacity']?.toJson(),
+          equals(passengerAttribute.toJson()),
+        );
+      },
+    );
+
+    test(
+      'Given model When toJson and fromJson then preserves canonical roundtrip',
+      () {
+        final Map<String, dynamic> json = model.toJson();
+        final ModelVehicle roundtrip = ModelVehicle.fromJson(json);
+
+        expect(roundtrip, equals(model));
+        expect(roundtrip.toJson(), equals(json));
+      },
+    );
+
+    test(
+      'Given missing optional collections When fromJson then defaults to empty collections and active state',
+      () {
+        final Map<String, dynamic> json = <String, dynamic>{
+          ModelVehicleEnum.id.name: 'vehicle-002',
+          ModelVehicleEnum.displayName.name: 'Vehicle 02',
+          ModelVehicleEnum.plate.name: '',
+          ModelVehicleEnum.brand.name: 'Toyota',
+          ModelVehicleEnum.model.name: 'Hilux',
+          ModelVehicleEnum.year.name: 0,
+          ModelVehicleEnum.description.name: '',
+          ModelVehicleEnum.vehicleCategory.name: defaultModelCategory.toJson(),
+        };
+
+        final ModelVehicle parsed = ModelVehicle.fromJson(json);
+
+        expect(parsed.tags, isEmpty);
+        expect(parsed.attributes, isEmpty);
+        expect(parsed.isActive, isTrue);
+        expect(parsed.toJson()[ModelVehicleEnum.tags.name], isEmpty);
+        expect(parsed.toJson()[ModelVehicleEnum.attributes.name], isEmpty);
+      },
+    );
+
+    test(
+      'Given legacy-ish raw attributes map When fromJson then normalizes into AttributeModel dictionary',
+      () {
+        final Map<String, dynamic> json = <String, dynamic>{
+          ModelVehicleEnum.id.name: 'vehicle-003',
+          ModelVehicleEnum.displayName.name: 'Vehicle 03',
+          ModelVehicleEnum.plate.name: 'XYZ987',
+          ModelVehicleEnum.brand.name: 'Kia',
+          ModelVehicleEnum.model.name: 'Picanto',
+          ModelVehicleEnum.year.name: 2020,
+          ModelVehicleEnum.description.name: 'Compact urban vehicle',
+          ModelVehicleEnum.isActive.name: false,
+          ModelVehicleEnum.vehicleCategory.name: vehicleCategory.toJson(),
+          ModelVehicleEnum.tags.name: const <Map<String, dynamic>>[],
+          ModelVehicleEnum.attributes.name: <String, dynamic>{
+            'color': 'red',
+            'batteryLevel': <String, dynamic>{
+              'name': 'batteryLevel',
+              'value': 87,
+            },
+          },
+        };
+
+        final ModelVehicle parsed = ModelVehicle.fromJson(json);
+
+        expect(parsed.isActive, isFalse);
+        expect(
+          parsed.attributes['color'],
+          equals(const AttributeModel<dynamic>(name: 'color', value: 'red')),
+        );
+        expect(
+          parsed.attributes['batteryLevel'],
+          equals(
+            const AttributeModel<dynamic>(name: 'batteryLevel', value: 87),
+          ),
+        );
+      },
+    );
+
+    test(
+      'Given model When copyWith overrides some fields then preserves the rest',
+      () {
+        final Map<String, AttributeModel<dynamic>> attributes =
+            <String, AttributeModel<dynamic>>{
+          'fuelType': const AttributeModel<String>(
+            name: 'fuelType',
+            value: 'electric',
+          ),
+        };
+
+        final ModelVehicle copy = model.copyWith(
+          displayName: 'Van 01 Updated',
+          year: 2025,
+          isActive: false,
+          attributes: attributes,
+        );
+
+        expect(copy.id, equals(model.id));
+        expect(copy.displayName, equals('Van 01 Updated'));
+        expect(copy.year, equals(2025));
+        expect(copy.isActive, isFalse);
+        expect(copy.vehicleCategory, equals(model.vehicleCategory));
+        expect(copy.tags, equals(model.tags));
+        expect(copy.attributes, same(attributes));
+        final ModelVehicle copyII = model.copyWith();
+        expect(copyII.toString(), equals(model.toString()));
+      },
+    );
+
+    test(
+      'Given equal vehicles with distinct map instances When compared then equality and hashCode stay stable',
+      () {
+        const ModelVehicle same = ModelVehicle(
+          id: 'vehicle-001',
+          displayName: 'Van 01',
+          plate: 'ABC123',
+          brand: 'Renault',
+          model: 'Kangoo',
+          year: 2024,
+          description: 'Urban delivery van',
+          isActive: true,
+          vehicleCategory: ModelCategory(
+            category: 'cargo-van',
+            description: 'Different description but same normalized category',
+          ),
+          tags: <ModelCategory>[
+            ModelCategory(
+              category: 'fleet-a',
+              description: 'Another description',
+            ),
+            ModelCategory(
+              category: 'urban-route',
+              description: 'Another tag description',
+            ),
+          ],
+          attributes: <String, AttributeModel<dynamic>>{
+            'color': AttributeModel<dynamic>(name: 'color', value: 'white'),
+            'passengerCapacity': AttributeModel<dynamic>(
+              name: 'passengerCapacity',
+              value: 2,
+            ),
+          },
+        );
+
+        expect(same, equals(model));
+        expect(same.hashCode, equals(model.hashCode));
+      },
+    );
+
+    test('defaultModelVehicle stays useful for tests', () {
+      expect(defaultModelVehicle.isActive, isTrue);
+      expect(defaultModelVehicle.tags, isEmpty);
+      expect(defaultModelVehicle.attributes, isEmpty);
+      expect(
+        defaultModelVehicle.toJson()[ModelVehicleEnum.vehicleCategory.name],
+        equals(defaultModelCategory.toJson()),
+      );
+    });
+  });
+  group('ModelVehicle.fromJson attributes list normalization', () {
+    test(
+      'Given empty attributes list When parsing Then returns an empty immutable attributes map',
+      () {
+        // Arrange
+        final Map<String, dynamic> json = <String, dynamic>{
+          ModelVehicleEnum.id.name: 'vehicle-1',
+          ModelVehicleEnum.displayName.name: 'Vehicle 1',
+          ModelVehicleEnum.plate.name: 'ABC123',
+          ModelVehicleEnum.brand.name: 'Brand',
+          ModelVehicleEnum.model.name: 'Model',
+          ModelVehicleEnum.year.name: 2024,
+          ModelVehicleEnum.description.name: 'Description',
+          ModelVehicleEnum.isActive.name: true,
+          ModelVehicleEnum.vehicleCategory.name: defaultModelCategory.toJson(),
+          ModelVehicleEnum.attributes.name: <dynamic>[],
+        };
+
+        // Act
+        final ModelVehicle result = ModelVehicle.fromJson(json);
+
+        // Assert
+        expect(result.attributes, isEmpty);
+        expect(
+          () => result.attributes['newKey'] = const AttributeModel<String>(
+            name: 'newKey',
+            value: 'value',
+          ),
+          throwsUnsupportedError,
+        );
+      },
+    );
+
+    test(
+      'Given attributes list with valid names When parsing Then stores each attribute by its name',
+      () {
+        // Arrange
+        final Map<String, dynamic> json = <String, dynamic>{
+          ModelVehicleEnum.id.name: 'vehicle-1',
+          ModelVehicleEnum.displayName.name: 'Vehicle 1',
+          ModelVehicleEnum.plate.name: 'ABC123',
+          ModelVehicleEnum.brand.name: 'Brand',
+          ModelVehicleEnum.model.name: 'Model',
+          ModelVehicleEnum.year.name: 2024,
+          ModelVehicleEnum.description.name: 'Description',
+          ModelVehicleEnum.isActive.name: true,
+          ModelVehicleEnum.vehicleCategory.name: defaultModelCategory.toJson(),
+          ModelVehicleEnum.attributes.name: <Map<String, dynamic>>[
+            <String, dynamic>{
+              AttributeEnum.name.name: 'fuelLevel',
+              AttributeEnum.value.name: 0.75,
+            },
+            <String, dynamic>{
+              AttributeEnum.name.name: 'passengers',
+              AttributeEnum.value.name: 4,
+            },
+          ],
+        };
+
+        // Act
+        final ModelVehicle result = ModelVehicle.fromJson(json);
+
+        // Assert
+        expect(result.attributes.length, 2);
+        expect(result.attributes.containsKey('fuelLevel'), isTrue);
+        expect(result.attributes.containsKey('passengers'), isTrue);
+        expect(result.attributes['fuelLevel']?.name, 'fuelLevel');
+        expect(result.attributes['fuelLevel']?.value, 0.75);
+        expect(result.attributes['passengers']?.name, 'passengers');
+        expect(result.attributes['passengers']?.value, 4);
+      },
+    );
+
+    test(
+      'Given attributes list with empty names When parsing Then skips unnamed attributes',
+      () {
+        // Arrange
+        final Map<String, dynamic> json = <String, dynamic>{
+          ModelVehicleEnum.id.name: 'vehicle-1',
+          ModelVehicleEnum.displayName.name: 'Vehicle 1',
+          ModelVehicleEnum.plate.name: 'ABC123',
+          ModelVehicleEnum.brand.name: 'Brand',
+          ModelVehicleEnum.model.name: 'Model',
+          ModelVehicleEnum.year.name: 2024,
+          ModelVehicleEnum.description.name: 'Description',
+          ModelVehicleEnum.isActive.name: true,
+          ModelVehicleEnum.vehicleCategory.name: defaultModelCategory.toJson(),
+          ModelVehicleEnum.attributes.name: <Map<String, dynamic>>[
+            <String, dynamic>{
+              AttributeEnum.name.name: '',
+              AttributeEnum.value.name: 'ignored',
+            },
+            <String, dynamic>{
+              AttributeEnum.name.name: 'cargoCapacity',
+              AttributeEnum.value.name: 1200,
+            },
+          ],
+        };
+
+        // Act
+        final ModelVehicle result = ModelVehicle.fromJson(json);
+
+        // Assert
+        expect(result.attributes.length, 1);
+        expect(result.attributes.containsKey('cargoCapacity'), isTrue);
+        expect(result.attributes.containsKey(''), isFalse);
+        expect(result.attributes['cargoCapacity']?.value, 1200);
+      },
+    );
+  });
+}


### PR DESCRIPTION
[1.39.4] - 2026-04-01

### Added
- **Vehicle base domain contract**
  - Nuevo módulo vehicular base con:
    - `ModelVehicle`
    - `ModelVehicleEnum`
  - `ModelVehicle` define un contrato transversal mínimo y reusable con:
    - identidad estructural (`id`, `displayName`, `plate`)
    - datos base (`brand`, `model`, `year`, `description`, `isActive`)
    - clasificación principal mediante `ModelCategory`
    - clasificación secundaria mediante `List<ModelCategory>`
    - extensibilidad operativa mediante `Map<String, AttributeModel<dynamic>>`
- **Vehicle unit tests**
  - Nuevas pruebas unitarias para `ModelVehicle` cubriendo:
    - roundtrip JSON canónico
    - `copyWith`
    - igualdad y `hashCode`
    - defaults
    - normalización defensiva de `attributes`
- **Vehicle JSON contracts**
  - Nuevos contratos y examples canónicos en `doc/schemas/v1/` para:
    - `model_vehicle.schema.json`
    - `examples/model_vehicle.example.json`

### Changed
- **Vehicle serialization semantics**
  - `ModelVehicle.toJson()` fija el shape canónico portable del vehículo.
  - `ModelVehicle.fromJson()` acepta variantes razonables para `attributes` y converge al contrato canonizado.
  - La igualdad y el hash de `attributes` se alinean con el contenido serializado para evitar falsas diferencias por genéricos Dart internos.
- **Schema documentation**
  - Se actualizan `doc/schemas/README.md` y `doc/schemas/v1/README.md` para reflejar:
    - la incorporación del contrato vehicular base
    - la reutilización de `ModelCategory` para clasificación
    - la reutilización de `AttributeModel` para extensibilidad controlada
- **Library exports**
  - Se registran los nuevos `part` del módulo vehicular en `lib/jocaagura_domain.dart`.

### Notes
- Esta fase cierra únicamente `ModelVehicle Base Contract v1`.
- La evolución hacia submodelos específicos de documentos, mantenimiento, energía o capacidad queda deliberadamente fuera de esta versión.
