### PR TITLE
Feat/add const constructor to either to allow const constructors in child classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ This document follows the guidelines of [Keep a Changelog](https://keepachangelo
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 Recent entries aim to follow a normalized structure. Older historical entries may preserve some original headings where reclassification would risk changing the original intent.
+## [1.40.0] - 2026-05-01
+
+### Changed
+- Added a `const` constructor to the `Either` base class and to its concrete variants:
+  - `Left`
+  - `Right`
+- Enabled compile-time constant creation for `Either` values when the contained value is also constant.
+- Applied the resulting linter-driven `const` updates across the package.
+
+### Quality
+- Completed 189 minor `prefer_const_constructors` updates suggested by the linter.
+- Verified that the package remains stable after the const migration.
+
+### Migration note
+- This change is backward compatible.
+- Consumers using strict lint rules may now receive additional `prefer_const_constructors` suggestions where `Left` or `Right` instances can be declared as `const`.
+- No behavioral changes were introduced for `when`, `fold`, `isLeft`, `isRight`, equality, `hashCode`, or `toString`.
 
 ## [1.39.5] - 2026-05-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Recent entries aim to follow a normalized structure. Older historical entries may preserve some original headings where reclassification would risk changing the original intent.
 
+## [1.39.5] - 2026-05-01
+
+### Changed
+- Added a `const` constructor to `Either`, `Left`, and `Right` to support compile-time constant values.
+
+### Migration note
+- This change is backward compatible. However, projects using strict lint rules may now receive `prefer_const_constructors` suggestions where `Left` or `Right` values can be declared as `const`.
+
 ## [1.39.4] - 2026-04-01
 
 ### Added

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -264,7 +264,7 @@ class _OnboardingSquareAreaValidationPageState
         title: 'Ingresa el lado',
         description:
             'Ingresa un número mayor que 0 y como máximo 100, luego confirma.',
-        onEnter: () async => Right<ErrorItem, Unit>(Unit.value),
+        onEnter: () async => const Right<ErrorItem, Unit>(Unit.value),
       ),
       OnboardingStep(
         title: 'Validación',
@@ -272,8 +272,8 @@ class _OnboardingSquareAreaValidationPageState
         onEnter: () async {
           final double? s = side;
           if (s == null || s <= 0) {
-            return Left<ErrorItem, Unit>(
-              const ErrorItem(
+            return const Left<ErrorItem, Unit>(
+              ErrorItem(
                 title: 'Lado inválido',
                 code: 'ERR_SIDE_NON_POSITIVE',
                 description: 'El lado debe ser mayor que 0.',
@@ -282,8 +282,8 @@ class _OnboardingSquareAreaValidationPageState
             );
           }
           if (s > 100) {
-            return Left<ErrorItem, Unit>(
-              const ErrorItem(
+            return const Left<ErrorItem, Unit>(
+              ErrorItem(
                 title: 'Lado demasiado grande',
                 code: 'ERR_SIDE_TOO_BIG',
                 description: 'El lado no puede ser mayor que 100.',
@@ -291,14 +291,14 @@ class _OnboardingSquareAreaValidationPageState
               ),
             );
           }
-          return Right<ErrorItem, Unit>(Unit.value);
+          return const Right<ErrorItem, Unit>(Unit.value);
         },
         autoAdvanceAfter: const Duration(milliseconds: 800),
       ),
       OnboardingStep(
         title: 'Resultado',
         description: 'Mostramos el área calculada y puedes finalizar.',
-        onEnter: () async => Right<ErrorItem, Unit>(Unit.value),
+        onEnter: () async => const Right<ErrorItem, Unit>(Unit.value),
       ),
       const OnboardingStep(
         title: 'Final',
@@ -680,7 +680,7 @@ class _BlocOnboardingDemoPageState extends State<BlocOnboardingDemoPage> {
         onEnter: () async {
           _logMsg('onEnter: Welcome (step 1)');
           await Future<void>.delayed(const Duration(milliseconds: 120));
-          return Right<ErrorItem, Unit>(Unit.value);
+          return const Right<ErrorItem, Unit>(Unit.value);
         },
         autoAdvanceAfter: const Duration(milliseconds: 900),
       ),
@@ -694,15 +694,15 @@ class _BlocOnboardingDemoPageState extends State<BlocOnboardingDemoPage> {
             throw StateError('Simulated thrown exception in step 2');
           }
           if (_failStep2AsLeft) {
-            return Left<ErrorItem, Unit>(
-              const ErrorItem(
+            return const Left<ErrorItem, Unit>(
+              ErrorItem(
                 title: 'Permissions required',
                 code: 'PERM_DENIED',
                 description: 'User denied permissions (simulated Left)',
               ),
             );
           }
-          return Right<ErrorItem, Unit>(Unit.value);
+          return const Right<ErrorItem, Unit>(Unit.value);
         },
         autoAdvanceAfter: const Duration(milliseconds: 900),
       ),
@@ -712,7 +712,7 @@ class _BlocOnboardingDemoPageState extends State<BlocOnboardingDemoPage> {
         onEnter: () async {
           _logMsg('onEnter: Finish (step 3)');
           await Future<void>.delayed(const Duration(milliseconds: 100));
-          return Right<ErrorItem, Unit>(Unit.value);
+          return const Right<ErrorItem, Unit>(Unit.value);
         },
       ),
     ]);

--- a/example/lib/onboarding_example.dart
+++ b/example/lib/onboarding_example.dart
@@ -74,7 +74,7 @@ class _OnboardingSquareAreaValidationPageState
         title: 'Ingresa el lado',
         description:
             'Ingresa un número mayor que 0 y como máximo 100, luego confirma.',
-        onEnter: () async => Right<ErrorItem, Unit>(Unit.value),
+        onEnter: () async => const Right<ErrorItem, Unit>(Unit.value),
       ),
       OnboardingStep(
         title: 'Validación',
@@ -85,8 +85,8 @@ class _OnboardingSquareAreaValidationPageState
           final double? s = side;
           // Reglas intencionalmente estrictas para demostrar manejo de errores:
           if (s == null || s <= 0) {
-            return Left<ErrorItem, Unit>(
-              const ErrorItem(
+            return const Left<ErrorItem, Unit>(
+              ErrorItem(
                 title: 'Lado inválido',
                 code: 'ERR_SIDE_NON_POSITIVE',
                 description: 'El lado debe ser mayor que 0.',
@@ -95,8 +95,8 @@ class _OnboardingSquareAreaValidationPageState
             );
           }
           if (s > 100) {
-            return Left<ErrorItem, Unit>(
-              const ErrorItem(
+            return const Left<ErrorItem, Unit>(
+              ErrorItem(
                 title: 'Lado demasiado grande',
                 code: 'ERR_SIDE_TOO_BIG',
                 description: 'El lado no puede ser mayor que 100.',
@@ -105,7 +105,7 @@ class _OnboardingSquareAreaValidationPageState
             );
           }
           // Éxito → Right
-          return Right<ErrorItem, Unit>(Unit.value);
+          return const Right<ErrorItem, Unit>(Unit.value);
         },
         // Si la validación fue exitosa, auto-avanzamos a "Resultado"
         autoAdvanceAfter: const Duration(milliseconds: 800),
@@ -113,7 +113,7 @@ class _OnboardingSquareAreaValidationPageState
       OnboardingStep(
         title: 'Resultado',
         description: 'Mostramos el área calculada y puedes finalizar.',
-        onEnter: () async => Right<ErrorItem, Unit>(Unit.value),
+        onEnter: () async => const Right<ErrorItem, Unit>(Unit.value),
       ),
       const OnboardingStep(
         title: 'Final',

--- a/example/lib/onboarding_example_advance.dart
+++ b/example/lib/onboarding_example_advance.dart
@@ -63,7 +63,7 @@ class _RiceOnboardingPageState extends State<RiceOnboardingPage> {
       OnboardingStep(
         title: '¿Para cuántas personas?',
         description: 'Ingresa un número entre 1 y 20 y confirma.',
-        onEnter: () async => Right<ErrorItem, Unit>(Unit.value),
+        onEnter: () async => const Right<ErrorItem, Unit>(Unit.value),
       ),
       OnboardingStep(
         title: 'Validación de porciones',
@@ -71,8 +71,8 @@ class _RiceOnboardingPageState extends State<RiceOnboardingPage> {
         onEnter: () async {
           final int? n = servings;
           if (n == null) {
-            return Left<ErrorItem, Unit>(
-              const ErrorItem(
+            return const Left<ErrorItem, Unit>(
+              ErrorItem(
                 title: 'Dato faltante',
                 code: 'ERR_NO_SERVINGS',
                 description: 'Debes ingresar el número de personas.',
@@ -81,8 +81,8 @@ class _RiceOnboardingPageState extends State<RiceOnboardingPage> {
             );
           }
           if (n < 1 || n > 20) {
-            return Left<ErrorItem, Unit>(
-              const ErrorItem(
+            return const Left<ErrorItem, Unit>(
+              ErrorItem(
                 title: 'Valor inválido',
                 code: 'ERR_RANGE',
                 description: 'El número debe estar entre 1 y 20.',
@@ -90,7 +90,7 @@ class _RiceOnboardingPageState extends State<RiceOnboardingPage> {
               ),
             );
           }
-          return Right<ErrorItem, Unit>(Unit.value);
+          return const Right<ErrorItem, Unit>(Unit.value);
         },
         // si es Right, avanza solo
         autoAdvanceAfter: const Duration(milliseconds: 900),
@@ -98,7 +98,7 @@ class _RiceOnboardingPageState extends State<RiceOnboardingPage> {
       OnboardingStep(
         title: 'Ingredientes',
         description: 'Cantidades ajustadas a tus porciones.',
-        onEnter: () async => Right<ErrorItem, Unit>(Unit.value),
+        onEnter: () async => const Right<ErrorItem, Unit>(Unit.value),
       ),
       const OnboardingStep(
         title: 'Cocción',

--- a/lib/domain/blocs/bloc_onboarding.dart
+++ b/lib/domain/blocs/bloc_onboarding.dart
@@ -348,7 +348,7 @@ class BlocOnboarding extends BlocModule {
       Either<ErrorItem, Unit> result;
       try {
         result =
-            await (step.onEnter?.call() ?? Right<ErrorItem, Unit>(Unit.value));
+            await (step.onEnter?.call() ?? const Right<ErrorItem, Unit>(Unit.value));
       } catch (e, s) {
         if (isDisposed ||
             epochAtCall != epoch ||

--- a/lib/domain/blocs/bloc_onboarding.dart
+++ b/lib/domain/blocs/bloc_onboarding.dart
@@ -347,8 +347,8 @@ class BlocOnboarding extends BlocModule {
     if (step.onEnter != null) {
       Either<ErrorItem, Unit> result;
       try {
-        result =
-            await (step.onEnter?.call() ?? const Right<ErrorItem, Unit>(Unit.value));
+        result = await (step.onEnter?.call() ??
+            const Right<ErrorItem, Unit>(Unit.value));
       } catch (e, s) {
         if (isDisposed ||
             epochAtCall != epoch ||

--- a/lib/domain/either.dart
+++ b/lib/domain/either.dart
@@ -1,32 +1,41 @@
 part of '../jocaagura_domain.dart';
 
-/// An abstract class representing an `Either` type, which can hold a value of
-/// one of two types: [L] or [R].
+/// Represents a value that can be either [Left] or [Right].
 ///
-/// This is commonly used to represent operations that can either succeed with
-/// a value of type [R] or fail with a value of type [L].
+/// Use [Left] to represent a failure or alternative value, and [Right] to
+/// represent a successful value.
 ///
-/// Example usage:
-///
+/// Functional example:
 /// ```dart
-/// Either<String, int> divide(int a, int b) {
-///   if (b == 0) {
-///     return Left('Division by zero');
-///   } else {
-///     return Right(a ~/ b);
+/// Either<String, int> divide(int dividend, int divisor) {
+///   if (divisor == 0) {
+///     return const Left<String, int>('Division by zero');
 ///   }
+///
+///   return Right<String, int>(dividend ~/ divisor);
 /// }
 ///
 /// void main() {
-///   final result = divide(10, 0);
-///   result.when(
-///     (error) => print('Error: $error'),
-///     (value) => print('Result: $value'),
+///   final Either<String, int> result = divide(10, 2);
+///
+///   final String message = result.when<String>(
+///     (String error) => 'Error: $error',
+///     (int value) => 'Result: $value',
 ///   );
+///
+///   print(message);
 /// }
 /// ```
+///
+/// Contract:
+/// - [Left] contains a value of type [L].
+/// - [Right] contains a value of type [R].
+/// - [when] and [fold] execute only the callback matching the current variant.
 @immutable
 abstract class Either<L, R> {
+  /// Creates an immutable [Either] value.
+  const Either();
+
   /// Executes one of the provided functions depending on the value type.
   ///
   /// If the value is a [Left], the [left] function is executed with the value
@@ -64,7 +73,7 @@ abstract class Either<L, R> {
 /// Represents a value of type [L] in the [Either] type.
 class Left<L, R> extends Either<L, R> {
   /// Constructs a [Left] object containing a value of type [L].
-  Left(this.value);
+  const Left(this.value);
 
   /// The value of type [L].
   final L value;
@@ -86,7 +95,7 @@ class Left<L, R> extends Either<L, R> {
 /// Represents a value of type [R] in the [Either] type.
 class Right<L, R> extends Either<L, R> {
   /// Constructs a [Right] object containing a value of type [R].
-  Right(this.value);
+  const Right(this.value);
 
   /// The value of type [R].
   final R value;

--- a/lib/domain/usecases/databases_crud/databases_crud_usecases.dart
+++ b/lib/domain/usecases/databases_crud/databases_crud_usecases.dart
@@ -356,11 +356,11 @@ class ExistsDocUseCase<T extends Model>
     final Either<ErrorItem, T> r = await _repo.read(params.docId);
     return r.fold((ErrorItem err) {
       if (err.code == DatabaseErrorItems.notFound.code) {
-        return Right<ErrorItem, bool>(false);
+        return const Right<ErrorItem, bool>(false);
       }
       return Left<ErrorItem, bool>(err);
     }, (_) {
-      return Right<ErrorItem, bool>(true);
+      return const Right<ErrorItem, bool>(true);
     });
   }
 }
@@ -848,7 +848,7 @@ class DetachWatchUseCase<T extends Model>
   Future<Either<ErrorItem, Unit>> call(DeleteParams params) async {
     try {
       _repo.detachWatch(params.docId);
-      return Right<ErrorItem, Unit>(Unit.value);
+      return const Right<ErrorItem, Unit>(Unit.value);
     } catch (e, s) {
       return Left<ErrorItem, Unit>(
         const DefaultErrorMapper().fromException(
@@ -886,7 +886,7 @@ class ReleaseDocUseCase<T extends Model>
   Future<Either<ErrorItem, Unit>> call(DeleteParams params) async {
     try {
       _repo.releaseDoc(params.docId);
-      return Right<ErrorItem, Unit>(Unit.value);
+      return const Right<ErrorItem, Unit>(Unit.value);
     } catch (e, s) {
       return Left<ErrorItem, Unit>(
         const DefaultErrorMapper().fromException(
@@ -929,7 +929,7 @@ class DisposeWsDatabaseUseCase<T extends Model>
   Future<Either<ErrorItem, Unit>> call(NoParams params) async {
     try {
       _repo.dispose();
-      return Right<ErrorItem, Unit>(Unit.value);
+      return const Right<ErrorItem, Unit>(Unit.value);
     } catch (e, s) {
       return Left<ErrorItem, Unit>(
         const DefaultErrorMapper().fromException(

--- a/lib/src/gateways/gateway_auth_impl.dart
+++ b/lib/src/gateways/gateway_auth_impl.dart
@@ -172,7 +172,7 @@ class GatewayAuthImpl implements GatewayAuth {
     try {
       await for (final Map<String, dynamic>? e in _service.authStateChanges()) {
         if (e == null) {
-          yield Right<ErrorItem, Map<String, dynamic>?>(null);
+          yield const Right<ErrorItem, Map<String, dynamic>?>(null);
           continue;
         }
         final ErrorItem? pe =

--- a/lib/src/gateways/gateway_ws_database_impl.dart
+++ b/lib/src/gateways/gateway_ws_database_impl.dart
@@ -136,7 +136,7 @@ class GatewayWsDatabaseImpl implements GatewayWsDatabase {
       }
 
       if (_treatEmptyAsMissing && json.isEmpty) {
-        return Left<ErrorItem, Map<String, dynamic>>(
+        return const Left<ErrorItem, Map<String, dynamic>>(
           DatabaseErrorItems.notFound,
         );
       }
@@ -190,7 +190,7 @@ class GatewayWsDatabaseImpl implements GatewayWsDatabase {
     _assertNotDisposed();
     try {
       await _service.deleteDocument(collection: _collection, docId: docId);
-      return Right<ErrorItem, Unit>(Unit.value);
+      return const Right<ErrorItem, Unit>(Unit.value);
     } catch (e, s) {
       return Left<ErrorItem, Unit>(
         _mapper.fromException(e, s, location: 'GatewayWsDatabase.delete'),
@@ -217,7 +217,7 @@ class GatewayWsDatabaseImpl implements GatewayWsDatabase {
     final _DocChannel channel = _channels.putIfAbsent(docId, () {
       final BlocGeneral<Either<ErrorItem, Map<String, dynamic>>> bloc =
           BlocGeneral<Either<ErrorItem, Map<String, dynamic>>>(
-        Right<ErrorItem, Map<String, dynamic>>(const <String, dynamic>{}),
+        const Right<ErrorItem, Map<String, dynamic>>(<String, dynamic>{}),
       );
 
       return _DocChannel(
@@ -243,7 +243,7 @@ class GatewayWsDatabaseImpl implements GatewayWsDatabase {
           },
           onDone: () {
             const ErrorItem closed = DatabaseErrorItems.streamClosed;
-            bloc.value = Left<ErrorItem, Map<String, dynamic>>(closed);
+            bloc.value = const Left<ErrorItem, Map<String, dynamic>>(closed);
           },
         ),
       );
@@ -312,7 +312,9 @@ class GatewayWsDatabaseImpl implements GatewayWsDatabase {
       return Left<ErrorItem, Map<String, dynamic>>(payloadErr);
     }
     if (_treatEmptyAsMissing && json.isEmpty) {
-      return Left<ErrorItem, Map<String, dynamic>>(DatabaseErrorItems.notFound);
+      return const Left<ErrorItem, Map<String, dynamic>>(
+        DatabaseErrorItems.notFound,
+      );
     }
     return Right<ErrorItem, Map<String, dynamic>>(_withId(docId, json));
   }

--- a/lib/src/gateways/gateway_ws_db_impl.dart
+++ b/lib/src/gateways/gateway_ws_db_impl.dart
@@ -138,7 +138,7 @@ class GatewayWsDbImpl implements GatewayWsDatabase {
       }
 
       if (_treatEmptyAsMissing && json.isEmpty) {
-        return Left<ErrorItem, Map<String, dynamic>>(
+        return const Left<ErrorItem, Map<String, dynamic>>(
           DatabaseErrorItems.notFound,
         );
       }
@@ -195,7 +195,7 @@ class GatewayWsDbImpl implements GatewayWsDatabase {
     _assertNotDisposed();
     try {
       await _service.deleteDocument(collection: _collection, docId: docId);
-      return Right<ErrorItem, Unit>(Unit.value);
+      return const Right<ErrorItem, Unit>(Unit.value);
     } catch (e, s) {
       return Left<ErrorItem, Unit>(
         _mapper.fromException(e, s, location: 'GatewayWsDatabase.delete'),
@@ -226,7 +226,7 @@ class GatewayWsDbImpl implements GatewayWsDatabase {
     final _DocChannel channel = _channels.putIfAbsent(docId, () {
       final BlocGeneral<Either<ErrorItem, Map<String, dynamic>>> bloc =
           BlocGeneral<Either<ErrorItem, Map<String, dynamic>>>(
-        Right<ErrorItem, Map<String, dynamic>>(const <String, dynamic>{}),
+        const Right<ErrorItem, Map<String, dynamic>>(<String, dynamic>{}),
       );
 
       return _DocChannel(
@@ -252,7 +252,7 @@ class GatewayWsDbImpl implements GatewayWsDatabase {
           },
           onDone: () {
             const ErrorItem closed = DatabaseErrorItems.streamClosed;
-            bloc.value = Left<ErrorItem, Map<String, dynamic>>(closed);
+            bloc.value = const Left<ErrorItem, Map<String, dynamic>>(closed);
           },
         ),
       );
@@ -330,7 +330,7 @@ class GatewayWsDbImpl implements GatewayWsDatabase {
       return Left<ErrorItem, Map<String, dynamic>>(payloadErr);
     }
     if (_treatEmptyAsMissing && json.isEmpty) {
-      return Left<ErrorItem, Map<String, dynamic>>(DatabaseErrorItems.notFound);
+      return const Left<ErrorItem, Map<String, dynamic>>(DatabaseErrorItems.notFound);
     }
     return Right<ErrorItem, Map<String, dynamic>>(_withId(docId, json));
   }

--- a/lib/src/gateways/gateway_ws_db_impl.dart
+++ b/lib/src/gateways/gateway_ws_db_impl.dart
@@ -330,7 +330,9 @@ class GatewayWsDbImpl implements GatewayWsDatabase {
       return Left<ErrorItem, Map<String, dynamic>>(payloadErr);
     }
     if (_treatEmptyAsMissing && json.isEmpty) {
-      return const Left<ErrorItem, Map<String, dynamic>>(DatabaseErrorItems.notFound);
+      return const Left<ErrorItem, Map<String, dynamic>>(
+        DatabaseErrorItems.notFound,
+      );
     }
     return Right<ErrorItem, Map<String, dynamic>>(_withId(docId, json));
   }

--- a/lib/src/repositories/repository_auth_impl.dart
+++ b/lib/src/repositories/repository_auth_impl.dart
@@ -89,7 +89,7 @@ class RepositoryAuthImpl implements RepositoryAuth {
     if (pe != null) {
       return Left<ErrorItem, void>(pe);
     }
-    return Right<ErrorItem, void>(null);
+    return const Right<ErrorItem, void>(null);
   }
 
   @override
@@ -244,7 +244,7 @@ class RepositoryAuthImpl implements RepositoryAuth {
         (ErrorItem err) async => Left<ErrorItem, UserModel?>(err),
         (Map<String, dynamic>? json) async {
           if (json == null) {
-            return Right<ErrorItem, UserModel?>(null);
+            return const Right<ErrorItem, UserModel?>(null);
           }
           final ErrorItem? pe = _err.fromPayload(
             json,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: jocaagura_domain
 description: "A package with domain models for all transversal applications"
 
-version: 1.39.4
+version: 1.40.0
 
 homepage: https://github.com/jocaagura/jocaagura_domain
 repository: https://github.com/jocaagura/jocaagura_domain

--- a/test/domain/blocs/bloc_connectivity_test.dart
+++ b/test/domain/blocs/bloc_connectivity_test.dart
@@ -51,9 +51,9 @@ void main() {
 
     test('loadInitial sets Right', () async {
       final _RepoStub repo = _RepoStub(
-        snapshotResult: Right<ErrorItem, ConnectivityModel>(initial),
-        typeResult: Right<ErrorItem, ConnectivityModel>(initial),
-        speedResult: Right<ErrorItem, ConnectivityModel>(initial),
+        snapshotResult: const Right<ErrorItem, ConnectivityModel>(initial),
+        typeResult: const Right<ErrorItem, ConnectivityModel>(initial),
+        speedResult: const Right<ErrorItem, ConnectivityModel>(initial),
       );
       final BlocConnectivity bloc = BlocConnectivity(
         watch: WatchConnectivityUseCase(repo),
@@ -71,9 +71,9 @@ void main() {
 
     test('startWatching propagates Right and Left', () async {
       final _RepoStub repo = _RepoStub(
-        snapshotResult: Right<ErrorItem, ConnectivityModel>(initial),
-        typeResult: Right<ErrorItem, ConnectivityModel>(initial),
-        speedResult: Right<ErrorItem, ConnectivityModel>(initial),
+        snapshotResult: const Right<ErrorItem, ConnectivityModel>(initial),
+        typeResult: const Right<ErrorItem, ConnectivityModel>(initial),
+        speedResult: const Right<ErrorItem, ConnectivityModel>(initial),
       );
       final BlocConnectivity bloc = BlocConnectivity(
         watch: WatchConnectivityUseCase(repo),
@@ -82,11 +82,11 @@ void main() {
         checkSpeed: CheckInternetSpeedUseCase(repo),
       );
       bloc.startWatching();
-      repo.emit(Right<ErrorItem, ConnectivityModel>(other));
+      repo.emit(const Right<ErrorItem, ConnectivityModel>(other));
       await Future<void>.delayed(const Duration(milliseconds: 5));
       expect((bloc.value as Right<ErrorItem, ConnectivityModel>).value, other);
 
-      repo.emit(Left<ErrorItem, ConnectivityModel>(err));
+      repo.emit(const Left<ErrorItem, ConnectivityModel>(err));
       await Future<void>.delayed(const Duration(milliseconds: 5));
       expect(bloc.value.isLeft, isTrue);
 
@@ -95,9 +95,9 @@ void main() {
 
     test('refreshType/refreshSpeed update value', () async {
       final _RepoStub repo = _RepoStub(
-        snapshotResult: Right<ErrorItem, ConnectivityModel>(initial),
-        typeResult: Right<ErrorItem, ConnectivityModel>(other),
-        speedResult: Right<ErrorItem, ConnectivityModel>(other),
+        snapshotResult: const Right<ErrorItem, ConnectivityModel>(initial),
+        typeResult: const Right<ErrorItem, ConnectivityModel>(other),
+        speedResult: const Right<ErrorItem, ConnectivityModel>(other),
       );
       final BlocConnectivity bloc = BlocConnectivity(
         watch: WatchConnectivityUseCase(repo),
@@ -114,9 +114,9 @@ void main() {
 
     test('stopWatching prevents further updates', () async {
       final _RepoStub repo = _RepoStub(
-        snapshotResult: Right<ErrorItem, ConnectivityModel>(initial),
-        typeResult: Right<ErrorItem, ConnectivityModel>(initial),
-        speedResult: Right<ErrorItem, ConnectivityModel>(initial),
+        snapshotResult: const Right<ErrorItem, ConnectivityModel>(initial),
+        typeResult: const Right<ErrorItem, ConnectivityModel>(initial),
+        speedResult: const Right<ErrorItem, ConnectivityModel>(initial),
       );
       final BlocConnectivity bloc = BlocConnectivity(
         watch: WatchConnectivityUseCase(repo),
@@ -127,7 +127,7 @@ void main() {
       bloc.startWatching();
       bloc.stopWatching();
       final Either<ErrorItem, ConnectivityModel> before = bloc.value;
-      repo.emit(Right<ErrorItem, ConnectivityModel>(other));
+      repo.emit(const Right<ErrorItem, ConnectivityModel>(other));
       await Future<void>.delayed(const Duration(milliseconds: 5));
       expect(bloc.value, before);
       bloc.dispose();

--- a/test/domain/blocs/bloc_http_request_test.dart
+++ b/test/domain/blocs/bloc_http_request_test.dart
@@ -383,7 +383,7 @@ void main() {
 
         final _FakeUsecaseHttpRequestPost fakePost =
             _FakeUsecaseHttpRequestPost()
-              ..result = Left<ErrorItem, ModelConfigHttpRequest>(error);
+              ..result = const Left<ErrorItem, ModelConfigHttpRequest>(error);
 
         final FacadeHttpRequestUsecases facade = FacadeHttpRequestUsecases(
           get: _FakeUsecaseHttpRequestGet(),
@@ -469,7 +469,7 @@ void main() {
         final _FakeUsecaseHttpRequestDelete fakeDelete =
             _FakeUsecaseHttpRequestDelete()
               ..delay = true
-              ..result = Left<ErrorItem, ModelConfigHttpRequest>(error);
+              ..result = const Left<ErrorItem, ModelConfigHttpRequest>(error);
 
         final FacadeHttpRequestUsecases facade = FacadeHttpRequestUsecases(
           get: _FakeUsecaseHttpRequestGet(),

--- a/test/domain/blocs/bloc_onboarding_extended_test.dart
+++ b/test/domain/blocs/bloc_onboarding_extended_test.dart
@@ -66,7 +66,7 @@ void main() {
         onEnter: () async {
           // Simular trabajo asíncrono rápido
           await Future<void>.delayed(const Duration(milliseconds: 5));
-          return Right<ErrorItem, Unit>(Unit.value);
+          return const Right<ErrorItem, Unit>(Unit.value);
         },
       );
       const OnboardingStep step2 = OnboardingStep(title: 'next');
@@ -91,8 +91,8 @@ void main() {
         title: 'fail',
         autoAdvanceAfter: const Duration(milliseconds: 20),
         onEnter: () async {
-          return Left<ErrorItem, Unit>(
-            const ErrorItem(
+          return const Left<ErrorItem, Unit>(
+            ErrorItem(
               title: 'X',
               code: 'ERR',
               description: 'boom',
@@ -158,15 +158,15 @@ void main() {
         onEnter: () async {
           attempts++;
           if (attempts == 1) {
-            return Left<ErrorItem, Unit>(
-              const ErrorItem(
+            return const Left<ErrorItem, Unit>(
+              ErrorItem(
                 title: 'F',
                 code: 'E1',
                 description: 'first',
               ),
             );
           }
-          return Right<ErrorItem, Unit>(Unit.value);
+          return const Right<ErrorItem, Unit>(Unit.value);
         },
         autoAdvanceAfter: const Duration(milliseconds: 20),
       );
@@ -196,8 +196,8 @@ void main() {
       // Arrange
       final OnboardingStep step = OnboardingStep(
         title: 'fail',
-        onEnter: () async => Left<ErrorItem, Unit>(
-          const ErrorItem(
+        onEnter: () async => const Left<ErrorItem, Unit>(
+          ErrorItem(
             title: 'X',
             code: 'ERR',
             description: 'boom',
@@ -293,8 +293,8 @@ void main() {
         title: 'slow-fail',
         onEnter: () async {
           await Future<void>.delayed(const Duration(milliseconds: 60));
-          return Left<ErrorItem, Unit>(
-            const ErrorItem(
+          return const Left<ErrorItem, Unit>(
+            ErrorItem(
               title: 'late',
               code: 'LATE',
               description: 'arrived too late',
@@ -304,7 +304,7 @@ void main() {
       );
       final OnboardingStep ok = OnboardingStep(
         title: 'ok',
-        onEnter: () async => Right<ErrorItem, Unit>(Unit.value),
+        onEnter: () async => const Right<ErrorItem, Unit>(Unit.value),
       );
       bloc.configure(<OnboardingStep>[slowFail, ok]);
 
@@ -335,8 +335,8 @@ void main() {
       // Arrange
       final OnboardingStep fail = OnboardingStep(
         title: 'fail',
-        onEnter: () async => Left<ErrorItem, Unit>(
-          const ErrorItem(
+        onEnter: () async => const Left<ErrorItem, Unit>(
+          ErrorItem(
             title: 'boom',
             code: 'ERR',
             description: 'x',
@@ -364,8 +364,8 @@ void main() {
       // Arrange
       final OnboardingStep fail = OnboardingStep(
         title: 'fail',
-        onEnter: () async => Left<ErrorItem, Unit>(
-          const ErrorItem(
+        onEnter: () async => const Left<ErrorItem, Unit>(
+          ErrorItem(
             title: 'boom',
             code: 'ERR',
             description: 'x',
@@ -397,7 +397,7 @@ void main() {
       final OnboardingStep s0 = OnboardingStep(
         title: 'auto',
         autoAdvanceAfter: const Duration(milliseconds: 60),
-        onEnter: () async => Right<ErrorItem, Unit>(Unit.value),
+        onEnter: () async => const Right<ErrorItem, Unit>(Unit.value),
       );
       const OnboardingStep s1 = OnboardingStep(title: 'next');
       bloc.configure(<OnboardingStep>[s0, s1]);
@@ -482,7 +482,7 @@ void main() {
           title: 'A',
           onEnter: () async {
             await Future<void>.delayed(const Duration(milliseconds: 10));
-            return Right<ErrorItem, Unit>(Unit.value);
+            return const Right<ErrorItem, Unit>(Unit.value);
           },
           autoAdvanceAfter: const Duration(milliseconds: 40),
         );
@@ -521,7 +521,7 @@ void main() {
         // Arrange
         final OnboardingStep a = OnboardingStep(
           title: 'A',
-          onEnter: () async => Right<ErrorItem, Unit>(Unit.value),
+          onEnter: () async => const Right<ErrorItem, Unit>(Unit.value),
           autoAdvanceAfter: const Duration(milliseconds: 40),
         );
         const OnboardingStep b = OnboardingStep(title: 'B');

--- a/test/domain/blocs/bloc_onboarding_test.dart
+++ b/test/domain/blocs/bloc_onboarding_test.dart
@@ -13,7 +13,7 @@ FutureOr<Either<ErrorItem, Unit>> Function() onEnterSuccess({
     if (delay > Duration.zero) {
       await Future<void>.delayed(delay);
     }
-    return Right<ErrorItem, Unit>(Unit.value);
+    return const Right<ErrorItem, Unit>(Unit.value);
   };
 }
 
@@ -296,7 +296,7 @@ void main() {
         if (mode == 'throw') {
           throw const FormatException('fail first');
         }
-        return Right<ErrorItem, Unit>(Unit.value);
+        return const Right<ErrorItem, Unit>(Unit.value);
       }
 
       bloc.configure(<OnboardingStep>[

--- a/test/domain/blocs/bloc_session_from_repository_test.dart
+++ b/test/domain/blocs/bloc_session_from_repository_test.dart
@@ -94,23 +94,23 @@ class _RepoFake implements RepositoryAuth {
 
   @override
   Future<Either<ErrorItem, void>> recoverPassword(String email) async {
-    return recoverResp ?? Right<ErrorItem, void>(null);
+    return recoverResp ?? const Right<ErrorItem, void>(null);
   }
 
   @override
   Future<Either<ErrorItem, void>> logOutUser(UserModel user) async {
-    return logoutResp ?? Right<ErrorItem, void>(null);
+    return logoutResp ?? const Right<ErrorItem, void>(null);
   }
 
   @override
   Future<Either<ErrorItem, UserModel>> getCurrentUser() async {
     return currentResp ??
-        Left<ErrorItem, UserModel>(SessionErrorItems.notSignedIn);
+        const Left<ErrorItem, UserModel>(SessionErrorItems.notSignedIn);
   }
 
   @override
   Future<Either<ErrorItem, bool>> isSignedIn() async {
-    return isSignedInResp ?? Right<ErrorItem, bool>(true);
+    return isSignedInResp ?? const Right<ErrorItem, bool>(true);
   }
 
   @override
@@ -138,7 +138,7 @@ void main() {
       await session.boot();
 
       // 1) signed-out
-      repo.addAuth(Right<ErrorItem, UserModel?>(null));
+      repo.addAuth(const Right<ErrorItem, UserModel?>(null));
       await Future<void>.delayed(const Duration(milliseconds: 1));
 
       // 2) signed-in
@@ -147,7 +147,7 @@ void main() {
 
       // 3) error
       repo.addAuth(
-        Left<ErrorItem, UserModel?>(SessionErrorItems.networkUnavailable),
+        const Left<ErrorItem, UserModel?>(SessionErrorItems.networkUnavailable),
       );
       await Future<void>.delayed(const Duration(milliseconds: 1));
 

--- a/test/domain/blocs/bloc_session_get_current_user_test.dart
+++ b/test/domain/blocs/bloc_session_get_current_user_test.dart
@@ -28,8 +28,8 @@ class FakeRepositoryAuth implements RepositoryAuth {
 
   @override
   Future<Either<ErrorItem, UserModel>> logInSilently(UserModel user) async =>
-      Left<ErrorItem, UserModel>(
-        const ErrorItem(title: 'stub', code: 'STUB', description: ''),
+      const Left<ErrorItem, UserModel>(
+        ErrorItem(title: 'stub', code: 'STUB', description: ''),
       );
 
   @override
@@ -37,34 +37,34 @@ class FakeRepositoryAuth implements RepositoryAuth {
     String email,
     String password,
   ) async =>
-      Left<ErrorItem, UserModel>(
-        const ErrorItem(title: 'stub', code: 'STUB', description: ''),
+      const Left<ErrorItem, UserModel>(
+        ErrorItem(title: 'stub', code: 'STUB', description: ''),
       );
 
   @override
   Future<Either<ErrorItem, UserModel>> logInWithGoogle() async =>
-      Left<ErrorItem, UserModel>(
-        const ErrorItem(title: 'stub', code: 'STUB', description: ''),
+      const Left<ErrorItem, UserModel>(
+        ErrorItem(title: 'stub', code: 'STUB', description: ''),
       );
 
   @override
   Future<Either<ErrorItem, void>> logOutUser(UserModel user) async =>
-      Left<ErrorItem, UserModel>(
-        const ErrorItem(title: 'stub', code: 'STUB', description: ''),
+      const Left<ErrorItem, UserModel>(
+        ErrorItem(title: 'stub', code: 'STUB', description: ''),
       );
 
   @override
   Future<Either<ErrorItem, void>> recoverPassword(String email) async =>
-      Left<ErrorItem, UserModel>(
-        const ErrorItem(title: 'stub', code: 'STUB', description: ''),
+      const Left<ErrorItem, UserModel>(
+        ErrorItem(title: 'stub', code: 'STUB', description: ''),
       );
 
   @override
   Future<Either<ErrorItem, UserModel>> refreshSession(
     UserModel currentUser,
   ) async =>
-      Left<ErrorItem, UserModel>(
-        const ErrorItem(title: 'stub', code: 'STUB', description: ''),
+      const Left<ErrorItem, UserModel>(
+        ErrorItem(title: 'stub', code: 'STUB', description: ''),
       );
 
   void dispose() {
@@ -116,7 +116,7 @@ void main() {
 
       repo = FakeRepositoryAuth(
         getCurrentUserBehavior: () async =>
-            Right<ErrorItem, UserModel>(expected),
+            const Right<ErrorItem, UserModel>(expected),
       );
       bloc = BlocSession.fromRepository(repository: repo);
 
@@ -157,7 +157,7 @@ void main() {
 
       repo = FakeRepositoryAuth(
         getCurrentUserBehavior: () async =>
-            Left<ErrorItem, UserModel>(expectedErr),
+            const Left<ErrorItem, UserModel>(expectedErr),
       );
       bloc = BlocSession.fromRepository(repository: repo);
 
@@ -195,8 +195,8 @@ void main() {
         'Then throws StateError', () async {
       // Arrange
       repo = FakeRepositoryAuth(
-        getCurrentUserBehavior: () async => Right<ErrorItem, UserModel>(
-          const UserModel(
+        getCurrentUserBehavior: () async => const Right<ErrorItem, UserModel>(
+          UserModel(
             id: 'u1',
             email: 'user@mail.com',
             displayName: 'user',
@@ -228,7 +228,7 @@ void main() {
       repo = FakeRepositoryAuth(
         getCurrentUserBehavior: () async {
           await Future<void>.delayed(const Duration(milliseconds: 50));
-          return Right<ErrorItem, UserModel>(expected);
+          return const Right<ErrorItem, UserModel>(expected);
         },
       );
       bloc = BlocSession.fromRepository(repository: repo);
@@ -255,7 +255,7 @@ void main() {
       repo = FakeRepositoryAuth(
         getCurrentUserBehavior: () async {
           await Future<void>.delayed(const Duration(milliseconds: 50));
-          return Right<ErrorItem, UserModel>(expected);
+          return const Right<ErrorItem, UserModel>(expected);
         },
       );
       bloc = BlocSession.fromRepository(repository: repo);

--- a/test/domain/blocs/bloc_session_hooks_test.dart
+++ b/test/domain/blocs/bloc_session_hooks_test.dart
@@ -22,11 +22,11 @@ class _RepoFake implements RepositoryAuth {
 
   @override
   Future<Either<ErrorItem, UserModel>> getCurrentUser() async =>
-      Left<ErrorItem, UserModel>(SessionErrorItems.notSignedIn);
+      const Left<ErrorItem, UserModel>(SessionErrorItems.notSignedIn);
 
   @override
   Future<Either<ErrorItem, bool>> isSignedIn() async =>
-      Right<ErrorItem, bool>(false);
+      const Right<ErrorItem, bool>(false);
 
   @override
   Future<Either<ErrorItem, UserModel>> logInSilently(
@@ -53,11 +53,11 @@ class _RepoFake implements RepositoryAuth {
 
   @override
   Future<Either<ErrorItem, void>> logOutUser(UserModel user) async =>
-      Right<ErrorItem, UserModel>(defaultUserModel);
+      const Right<ErrorItem, UserModel>(defaultUserModel);
 
   @override
   Future<Either<ErrorItem, void>> recoverPassword(String email) async =>
-      Right<ErrorItem, UserModel>(defaultUserModel);
+      const Right<ErrorItem, UserModel>(defaultUserModel);
 
   @override
   Future<Either<ErrorItem, UserModel>> refreshSession(
@@ -119,7 +119,7 @@ void main() {
       await session.boot();
 
       // 1) signed-out
-      repo.addAuth(Right<ErrorItem, UserModel?>(null));
+      repo.addAuth(const Right<ErrorItem, UserModel?>(null));
       await Future<void>.delayed(const Duration(milliseconds: 1));
 
       // 2) signed-in
@@ -128,7 +128,7 @@ void main() {
 
       // 3) error
       repo.addAuth(
-        Left<ErrorItem, UserModel?>(SessionErrorItems.networkUnavailable),
+        const Left<ErrorItem, UserModel?>(SessionErrorItems.networkUnavailable),
       );
       await Future<void>.delayed(const Duration(milliseconds: 1));
 
@@ -157,7 +157,7 @@ void main() {
       await session.boot();
 
       // Primera emisión: debería incrementar
-      repo.addAuth(Right<ErrorItem, UserModel?>(null));
+      repo.addAuth(const Right<ErrorItem, UserModel?>(null));
       await Future<void>.delayed(const Duration(milliseconds: 1));
       expect(calls, greaterThanOrEqualTo(1));
 
@@ -203,7 +203,7 @@ void main() {
       session.addFunctionToProcessTValueOnStream('dup', (_) => a++);
       await session.boot();
 
-      repo.addAuth(Right<ErrorItem, UserModel?>(null));
+      repo.addAuth(const Right<ErrorItem, UserModel?>(null));
       await Future<void>.delayed(const Duration(milliseconds: 1));
       expect(a, greaterThanOrEqualTo(1));
       expect(b, 0);
@@ -218,7 +218,9 @@ void main() {
       final int aAfter = a;
       expect(b, greaterThanOrEqualTo(1));
 
-      repo.addAuth(Left<ErrorItem, UserModel?>(SessionErrorItems.timeout));
+      repo.addAuth(
+        const Left<ErrorItem, UserModel?>(SessionErrorItems.timeout),
+      );
       await Future<void>.delayed(const Duration(milliseconds: 1));
       expect(a, aAfter); // a no cambió
 

--- a/test/domain/blocs/bloc_session_test.dart
+++ b/test/domain/blocs/bloc_session_test.dart
@@ -53,7 +53,7 @@ void main() {
 
       await bloc.boot();
 
-      repo.emitAuth(Right<ErrorItem, UserModel?>(null));
+      repo.emitAuth(const Right<ErrorItem, UserModel?>(null));
       await waitForState(
         bloc.sessionStream,
         (SessionState s) => s is Unauthenticated,
@@ -67,7 +67,7 @@ void main() {
         email: 'u1@x.com',
         jwt: <String, dynamic>{},
       );
-      repo.emitAuth(Right<ErrorItem, UserModel?>(u));
+      repo.emitAuth(const Right<ErrorItem, UserModel?>(u));
       await waitForState(
         bloc.sessionStream,
         (SessionState state) => state is Authenticated,
@@ -81,7 +81,7 @@ void main() {
         code: 'ERR_X',
         description: 'fail',
       );
-      repo.emitAuth(Left<ErrorItem, UserModel?>(err));
+      repo.emitAuth(const Left<ErrorItem, UserModel?>(err));
       await waitForState(
         bloc.sessionStream,
         (SessionState s) => s is SessionError,
@@ -105,8 +105,8 @@ void main() {
     });
 
     test('logIn() error → SessionError', () async {
-      repo.nextLoginResult = Left<ErrorItem, UserModel>(
-        const ErrorItem(title: 'Bad', code: 'ERR_LOGIN', description: 'nope'),
+      repo.nextLoginResult = const Left<ErrorItem, UserModel>(
+        ErrorItem(title: 'Bad', code: 'ERR_LOGIN', description: 'nope'),
       );
       final Either<ErrorItem, UserModel> r =
           await bloc.logIn(email: 'me@mail.com', password: 'secret');
@@ -160,7 +160,7 @@ void main() {
         email: 'a@x.com',
         jwt: <String, dynamic>{'t': 1},
       );
-      repo.emitAuth(Right<ErrorItem, UserModel?>(base));
+      repo.emitAuth(const Right<ErrorItem, UserModel?>(base));
       await waitForState(
         bloc.sessionStream,
         (SessionState s) => s is Authenticated,
@@ -200,12 +200,12 @@ void main() {
         email: 'r@x.com',
         jwt: <String, dynamic>{'t': 1},
       );
-      repo.emitAuth(Right<ErrorItem, UserModel?>(base));
+      repo.emitAuth(const Right<ErrorItem, UserModel?>(base));
       await waitForState(bloc.stream, (SessionState s) => s is Authenticated);
 
       // Forzamos fallo en refresh
-      repo.nextRefreshResult = Left<ErrorItem, UserModel>(
-        const ErrorItem(title: 'x', code: 'ERR_REFRESH', description: 'fail'),
+      repo.nextRefreshResult = const Left<ErrorItem, UserModel>(
+        ErrorItem(title: 'x', code: 'ERR_REFRESH', description: 'fail'),
       );
 
       final Either<ErrorItem, UserModel>? r = await bloc.refreshSession();
@@ -229,7 +229,7 @@ void main() {
         email: 'c@x.com',
         jwt: <String, dynamic>{},
       );
-      repo.emitAuth(Right<ErrorItem, UserModel?>(u));
+      repo.emitAuth(const Right<ErrorItem, UserModel?>(u));
       await waitForState(
         bloc.sessionStream,
         (SessionState s) => s is Authenticated,
@@ -248,8 +248,8 @@ void main() {
     });
 
     test('recoverPassword() error → SessionError', () async {
-      repo.nextRecoverResult = Left<ErrorItem, void>(
-        const ErrorItem(title: 'x', code: 'ERR_REC', description: 'fail'),
+      repo.nextRecoverResult = const Left<ErrorItem, void>(
+        ErrorItem(title: 'x', code: 'ERR_REC', description: 'fail'),
       );
       final Either<ErrorItem, void> r =
           await bloc.recoverPassword(email: 'z@x.com');
@@ -270,7 +270,7 @@ void main() {
         email: 'd@x.com',
         jwt: <String, dynamic>{},
       );
-      repo.emitAuth(Right<ErrorItem, UserModel?>(u));
+      repo.emitAuth(const Right<ErrorItem, UserModel?>(u));
       await waitForState(
         bloc.sessionStream,
         (SessionState s) => s is Authenticated,
@@ -306,8 +306,8 @@ void main() {
       expect(bloc.isAuthenticated, isFalse);
       await bloc.boot();
       repo.emitAuth(
-        Right<ErrorItem, UserModel?>(
-          const UserModel(
+        const Right<ErrorItem, UserModel?>(
+          UserModel(
             id: 'idE',
             displayName: 'e',
             photoUrl: '',
@@ -333,8 +333,8 @@ void main() {
       expect(repo.logInUserAndPasswordCalls, 1);
     });
     test('logInWithGoogle() error → SessionError', () async {
-      repo.nextGoogleResult = Left<ErrorItem, UserModel>(
-        const ErrorItem(
+      repo.nextGoogleResult = const Left<ErrorItem, UserModel>(
+        ErrorItem(
           title: 'google',
           code: 'ERR_GOOGLE',
           description: 'fail',
@@ -363,14 +363,14 @@ void main() {
         email: 's@x.com',
         jwt: <String, dynamic>{},
       );
-      repo.emitAuth(Right<ErrorItem, UserModel?>(base));
+      repo.emitAuth(const Right<ErrorItem, UserModel?>(base));
       await waitForState(
         bloc.sessionStream,
         (SessionState s) => s is Authenticated,
       );
 
-      repo.nextSilentResult = Left<ErrorItem, UserModel>(
-        const ErrorItem(
+      repo.nextSilentResult = const Left<ErrorItem, UserModel>(
+        ErrorItem(
           title: 'silent',
           code: 'ERR_SILENT',
           description: 'boom',
@@ -398,7 +398,7 @@ void main() {
       );
 
       // 1) Autenticamos con el "base"
-      repo.emitAuth(Right<ErrorItem, UserModel?>(base));
+      repo.emitAuth(const Right<ErrorItem, UserModel?>(base));
       await waitForState(
         bloc.sessionStream,
         (SessionState s) => s is Authenticated && s.user.email == base.email,
@@ -488,7 +488,7 @@ void main() {
       await bloc.boot();
 
       // 1) Right(null) -> Unauthenticated (explícito, aunque ya recibimos uno por replay)
-      repo.emitAuth(Right<ErrorItem, UserModel?>(null));
+      repo.emitAuth(const Right<ErrorItem, UserModel?>(null));
       await waitForState(bloc.stream, (SessionState s) => s is Unauthenticated);
 
       // 2) Right(user1) -> Authenticated
@@ -499,11 +499,11 @@ void main() {
         email: 'u1@x.com',
         jwt: <String, dynamic>{'v': 1},
       );
-      repo.emitAuth(Right<ErrorItem, UserModel?>(user1));
+      repo.emitAuth(const Right<ErrorItem, UserModel?>(user1));
       await waitForState(bloc.stream, (SessionState s) => s is Authenticated);
 
       // 3) Right(null) -> Unauthenticated
-      repo.emitAuth(Right<ErrorItem, UserModel?>(null));
+      repo.emitAuth(const Right<ErrorItem, UserModel?>(null));
       await waitForState(bloc.stream, (SessionState s) => s is Unauthenticated);
 
       // 4) Right(user2) -> Authenticated (cambiar el payload para evitar colisiones de igualdad)
@@ -516,7 +516,7 @@ void main() {
           'v': 2,
         }, // <-- cambia algo (ej. jwt) para asegurar nueva emisión
       );
-      repo.emitAuth(Right<ErrorItem, UserModel?>(user2));
+      repo.emitAuth(const Right<ErrorItem, UserModel?>(user2));
       await waitForState(bloc.stream, (SessionState s) => s is Authenticated);
 
       // Dar un tick para drenar microtasks
@@ -556,7 +556,7 @@ void main() {
         jwt: <String, dynamic>{'k': 1},
       );
 
-      repo.emitAuth(Right<ErrorItem, UserModel?>(u));
+      repo.emitAuth(const Right<ErrorItem, UserModel?>(u));
       await waitForState(
         bloc.sessionStream,
         (SessionState s) => s is Authenticated && s.user.email == u.email,
@@ -592,7 +592,7 @@ void main() {
         email: 'z@x.com',
         jwt: <String, dynamic>{},
       );
-      repo.emitAuth(Right<ErrorItem, UserModel?>(u));
+      repo.emitAuth(const Right<ErrorItem, UserModel?>(u));
       await waitForState(
         bloc.sessionStream,
         (SessionState s) => s is Authenticated,
@@ -615,7 +615,7 @@ void main() {
       final StreamSubscription<SessionState> sub = bloc.stream.listen(seen.add);
 
       await bloc.boot();
-      repo.emitAuth(Right<ErrorItem, UserModel?>(null));
+      repo.emitAuth(const Right<ErrorItem, UserModel?>(null));
       await waitForState(bloc.stream, (SessionState s) => s is Unauthenticated);
 
       expect(seen.last, isA<Unauthenticated>());
@@ -631,13 +631,13 @@ void main() {
           bloc.stream.listen((SessionState s) => seen.add(s.runtimeType));
 
       // 1) Unauthenticated
-      repo.emitAuth(Right<ErrorItem, UserModel?>(null));
+      repo.emitAuth(const Right<ErrorItem, UserModel?>(null));
       await waitForState(bloc.stream, (SessionState s) => s is Unauthenticated);
 
       // 2) Authenticated
       repo.emitAuth(
-        Right<ErrorItem, UserModel?>(
-          const UserModel(
+        const Right<ErrorItem, UserModel?>(
+          UserModel(
             id: 'a',
             displayName: 'a',
             photoUrl: '',
@@ -753,13 +753,13 @@ void main() {
           email: 'x@x.com',
           jwt: <String, dynamic>{},
         );
-        repo.emitAuth(Right<ErrorItem, UserModel?>(u));
+        repo.emitAuth(const Right<ErrorItem, UserModel?>(u));
         await waitForState(bloc.stream, (SessionState s) => s is Authenticated);
 
         bloc.dispose();
 
         // Cambios ya no deben reflejarse
-        repo.emitAuth(Right<ErrorItem, UserModel?>(null));
+        repo.emitAuth(const Right<ErrorItem, UserModel?>(null));
         // No podemos leer getters (lanzan). Validamos que el stream tampoco es accesible.
         expect(() => bloc.sessionStream, throwsStateError);
       });
@@ -793,7 +793,7 @@ void main() {
           email: 'l@x.com',
           jwt: <String, dynamic>{'k': 7},
         );
-        repo.emitAuth(Right<ErrorItem, UserModel?>(u));
+        repo.emitAuth(const Right<ErrorItem, UserModel?>(u));
         await waitForState(bloc.stream, (SessionState s) => s is Authenticated);
 
         bloc.dispose();
@@ -816,7 +816,7 @@ void main() {
           email: 'l2@x.com',
           jwt: <String, dynamic>{},
         );
-        repo.emitAuth(Right<ErrorItem, UserModel?>(u));
+        repo.emitAuth(const Right<ErrorItem, UserModel?>(u));
         await waitForState(bloc.stream, (SessionState s) => s is Authenticated);
 
         bloc.dispose();
@@ -853,8 +853,8 @@ void main() {
       test('no refleja nuevos cambios del repo tras dispose()', () async {
         await bloc.boot();
         repo.emitAuth(
-          Right<ErrorItem, UserModel?>(
-            const UserModel(
+          const Right<ErrorItem, UserModel?>(
+            UserModel(
               id: 'idLS',
               displayName: 'LS',
               photoUrl: '',
@@ -868,7 +868,7 @@ void main() {
         bloc.dispose();
 
         // El repo cambia a Unauthenticated, pero el snapshot se mantiene.
-        repo.emitAuth(Right<ErrorItem, UserModel?>(null));
+        repo.emitAuth(const Right<ErrorItem, UserModel?>(null));
         await Future<void>.delayed(const Duration(milliseconds: 20));
 
         expect(bloc.state, isA<Authenticated>());

--- a/test/domain/blocs/bloc_ws_database_ext_test.dart
+++ b/test/domain/blocs/bloc_ws_database_ext_test.dart
@@ -17,7 +17,7 @@ class RepoFake implements RepositoryWsDatabase<UserModel> {
   Future<Either<ErrorItem, UserModel>> read(String docId) async {
     final UserModel? u = _store[docId];
     if (u == null) {
-      return Left<ErrorItem, UserModel>(DatabaseErrorItems.notFound);
+      return const Left<ErrorItem, UserModel>(DatabaseErrorItems.notFound);
     }
     return Right<ErrorItem, UserModel>(u);
   }
@@ -36,8 +36,8 @@ class RepoFake implements RepositoryWsDatabase<UserModel> {
   Future<Either<ErrorItem, Unit>> delete(String docId) async {
     _store.remove(docId);
     _streams[docId]
-        ?.add(Left<ErrorItem, UserModel>(DatabaseErrorItems.notFound));
-    return Right<ErrorItem, Unit>(Unit.value);
+        ?.add(const Left<ErrorItem, UserModel>(DatabaseErrorItems.notFound));
+    return const Right<ErrorItem, Unit>(Unit.value);
   }
 
   @override
@@ -52,7 +52,7 @@ class RepoFake implements RepositoryWsDatabase<UserModel> {
       final UserModel? u = _store[docId];
       ctrl.add(
         u == null
-            ? Left<ErrorItem, UserModel>(DatabaseErrorItems.notFound)
+            ? const Left<ErrorItem, UserModel>(DatabaseErrorItems.notFound)
             : Right<ErrorItem, UserModel>(u),
       );
     });

--- a/test/domain/blocs/bloc_ws_database_test.dart
+++ b/test/domain/blocs/bloc_ws_database_test.dart
@@ -85,7 +85,7 @@ void main() {
 
       // Ahora simulamos error
       repo.onRead = (String id) async =>
-          Left<ErrorItem, UserModel>(DatabaseErrorItems.notFound);
+          const Left<ErrorItem, UserModel>(DatabaseErrorItems.notFound);
 
       final Either<ErrorItem, UserModel> res = await bloc.readDoc(kDoc);
       expect(res.isLeft, isTrue);
@@ -113,7 +113,7 @@ void main() {
     test('writeDoc error: setea error', () async {
       final UserModel u = makeUser();
       repo.onWrite = (String id, UserModel e) async =>
-          Left<ErrorItem, UserModel>(DatabaseErrorItems.conflict);
+          const Left<ErrorItem, UserModel>(DatabaseErrorItems.conflict);
 
       final Either<ErrorItem, UserModel> res = await bloc.writeDoc(kDoc, u);
       expect(res.isLeft, isTrue);
@@ -127,7 +127,8 @@ void main() {
       await bloc.readDoc(kDoc);
       expect(bloc.value.doc, isNotNull);
 
-      repo.onDelete = (String id) async => Right<ErrorItem, Unit>(Unit.value);
+      repo.onDelete =
+          (String id) async => const Right<ErrorItem, Unit>(Unit.value);
 
       final Either<ErrorItem, Unit> res = await bloc.deleteDoc(kDoc);
       expect(res.isRight, isTrue);
@@ -139,7 +140,7 @@ void main() {
       repo.onRead = (String id) async => Right<ErrorItem, UserModel>(u);
       await bloc.readDoc(kDoc);
 
-      repo.onExists = (String id) async => Right<ErrorItem, bool>(true);
+      repo.onExists = (String id) async => const Right<ErrorItem, bool>(true);
 
       final Either<ErrorItem, bool> res = await bloc.existsDoc(kDoc);
       expect(res.isRight, isTrue);
@@ -154,7 +155,7 @@ void main() {
       final UserModel base = makeUser();
       // read inexistente -> simulate notFound
       repo.onRead = (String _) async =>
-          Left<ErrorItem, UserModel>(DatabaseErrorItems.notFound);
+          const Left<ErrorItem, UserModel>(DatabaseErrorItems.notFound);
       repo.onWrite =
           (String _, UserModel e) async => Right<ErrorItem, UserModel>(e);
 
@@ -205,7 +206,10 @@ void main() {
       expect(bloc.value.doc, equals(u1));
 
       // Emite un Left (error)
-      repo.emit(kDoc, Left<ErrorItem, UserModel>(DatabaseErrorItems.timeout));
+      repo.emit(
+        kDoc,
+        const Left<ErrorItem, UserModel>(DatabaseErrorItems.timeout),
+      );
       await flush();
       expect(bloc.value.error, isNotNull);
       expect(bloc.value.error!.code, DatabaseErrorItems.timeout.code);

--- a/test/domain/either_complement_test.dart
+++ b/test/domain/either_complement_test.dart
@@ -1,0 +1,90 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jocaagura_domain/jocaagura_domain.dart';
+
+void main() {
+  group('Either const constructor', () {
+    test('Given const Left values When compared Then they are equal', () {
+      const Left<String, int> first = Left<String, int>('error');
+      const Left<String, int> second = Left<String, int>('error');
+
+      expect(first, second);
+      expect(identical(first, second), isTrue);
+    });
+
+    test('Given const Right values When compared Then they are equal', () {
+      const Right<String, int> first = Right<String, int>(1);
+      const Right<String, int> second = Right<String, int>(1);
+
+      expect(first, second);
+      expect(identical(first, second), isTrue);
+    });
+  });
+
+  group('Either when', () {
+    test('Given Left When when is called Then executes left callback', () {
+      const Either<String, int> result = Left<String, int>('error');
+
+      final String message = result.when<String>(
+        (String error) => 'left: $error',
+        (int value) => 'right: $value',
+      );
+
+      expect(message, 'left: error');
+    });
+
+    test('Given Right When when is called Then executes right callback', () {
+      const Either<String, int> result = Right<String, int>(1);
+
+      final String message = result.when<String>(
+        (String error) => 'left: $error',
+        (int value) => 'right: $value',
+      );
+
+      expect(message, 'right: 1');
+    });
+  });
+
+  group('Either fold', () {
+    test('Given Left When fold is called Then executes onLeft callback', () {
+      const Either<String, int> result = Left<String, int>('error');
+
+      final String message = result.fold<String>(
+        (String error) => 'left: $error',
+        (int value) => 'right: $value',
+      );
+
+      expect(message, 'left: error');
+    });
+
+    test('Given Right When fold is called Then executes onRight callback', () {
+      const Either<String, int> result = Right<String, int>(1);
+
+      final String message = result.fold<String>(
+        (String error) => 'left: $error',
+        (int value) => 'right: $value',
+      );
+
+      expect(message, 'right: 1');
+    });
+  });
+
+  group('Either type flags', () {
+    test(
+        'Given Left When flags are read Then isLeft is true and isRight is false',
+        () {
+      const Either<String, int> result = Left<String, int>('error');
+
+      expect(result.isLeft, isTrue);
+      expect(result.isRight, isFalse);
+    });
+
+    test(
+        'Given Right When flags are read Then isRight is true and isLeft is false',
+        () {
+      const Either<String, int> result = Right<String, int>(1);
+
+      expect(result.isRight, isTrue);
+      expect(result.isLeft, isFalse);
+    });
+  });
+}

--- a/test/domain/either_test.dart
+++ b/test/domain/either_test.dart
@@ -5,7 +5,7 @@ void main() {
   group('Either', () {
     // Test for Left
     test('Left should return correct value and type', () {
-      final Left<int, String> left = Left<int, String>(42);
+      const Left<int, String> left = Left<int, String>(42);
 
       expect(left.isLeft, true);
       expect(left.isRight, false);
@@ -21,8 +21,8 @@ void main() {
 
     // Test for Right
     test('Right should return correct value and type', () {
-      final Right<int, String> right = Right<int, String>('hello');
-      final Right<int, String> right2 = Right<int, String>('hello');
+      const Right<int, String> right = Right<int, String>('hello');
+      const Right<int, String> right2 = Right<int, String>('hello');
 
       expect(right.isLeft, false);
       expect(right.isRight, true);
@@ -39,9 +39,9 @@ void main() {
 
     // Test for when method
     test('Either.when should execute correct function', () {
-      final Left<int, String> left = Left<int, String>(42);
-      final Left<int, String> left2 = Left<int, String>(42);
-      final Right<int, String> right = Right<int, String>('hello');
+      const Left<int, String> left = Left<int, String>(42);
+      const Left<int, String> left2 = Left<int, String>(42);
+      const Right<int, String> right = Right<int, String>('hello');
       expect(left2 == left, true);
 
       expect(

--- a/test/domain/states/onboarding_step_test.dart
+++ b/test/domain/states/onboarding_step_test.dart
@@ -12,7 +12,7 @@ Future<Either<ErrorItem, Unit>> activateStep(OnboardingStep step) async {
     if (step.autoAdvanceAfter != null) {
       await Future<void>.delayed(step.autoAdvanceAfter!);
     }
-    return Right<ErrorItem, Unit>(unit);
+    return const Right<ErrorItem, Unit>(unit);
   }
 
   final Either<ErrorItem, Unit> result = await step.onEnter!();
@@ -50,7 +50,7 @@ void main() {
       final OnboardingStep step = OnboardingStep(
         title: 'Permisos',
         autoAdvanceAfter: delay,
-        onEnter: () async => Right<ErrorItem, Unit>(unit),
+        onEnter: () async => const Right<ErrorItem, Unit>(unit),
       );
 
       // Act + Assert (no medimos el tiempo exacto, solo que no falla y es Right)
@@ -68,8 +68,8 @@ void main() {
         autoAdvanceAfter: const Duration(milliseconds: 20),
         onEnter: () {
           tick++; // Se ejecuta una vez
-          return Left<ErrorItem, Unit>(
-            const ErrorItem(
+          return const Left<ErrorItem, Unit>(
+            ErrorItem(
               code: 'VALIDATION_FAIL',
               title: 'Datos inválidos',
               description: 'Datos inválidos',
@@ -127,7 +127,7 @@ void main() {
       final OnboardingStep step = OnboardingStep(
         title: 'Sincronización',
         autoAdvanceAfter: delay,
-        onEnter: () async => Right<ErrorItem, Unit>(unit),
+        onEnter: () async => const Right<ErrorItem, Unit>(unit),
       );
 
       // Act

--- a/test/mocks_and_fakes/fake_repository_auth.dart
+++ b/test/mocks_and_fakes/fake_repository_auth.dart
@@ -27,7 +27,7 @@ class FakeRepositoryAuth implements RepositoryAuth {
 
   final BlocGeneral<Either<ErrorItem, UserModel?>> _authCtrl =
       BlocGeneral<Either<ErrorItem, UserModel?>>(
-    Right<ErrorItem, UserModel?>(defaultUserModel),
+    const Right<ErrorItem, UserModel?>(defaultUserModel),
   );
 
   void emitAuth(Either<ErrorItem, UserModel?> error) {
@@ -79,8 +79,8 @@ class FakeRepositoryAuth implements RepositoryAuth {
   Future<Either<ErrorItem, UserModel>> logInWithGoogle() async {
     logInWithGoogleCalls++;
     return nextGoogleResult ??
-        Right<ErrorItem, UserModel>(
-          const UserModel(
+        const Right<ErrorItem, UserModel>(
+          UserModel(
             id: 'google_user',
             displayName: 'Fake User',
             photoUrl: 'https://fake.com/photo.png',
@@ -119,21 +119,21 @@ class FakeRepositoryAuth implements RepositoryAuth {
   @override
   Future<Either<ErrorItem, void>> recoverPassword(String email) async {
     recoverPasswordCalls++;
-    return nextRecoverResult ?? Right<ErrorItem, void>(null);
+    return nextRecoverResult ?? const Right<ErrorItem, void>(null);
   }
 
   @override
   Future<Either<ErrorItem, void>> logOutUser(UserModel user) async {
     logOutUserCalls++;
-    return nextLogoutResult ?? Right<ErrorItem, void>(null);
+    return nextLogoutResult ?? const Right<ErrorItem, void>(null);
   }
 
   @override
   Future<Either<ErrorItem, UserModel>> getCurrentUser() async {
     getCurrentUserCalls++;
     return nextGetCurrentUserResult ??
-        Left<ErrorItem, UserModel>(
-          const ErrorItem(
+        const Left<ErrorItem, UserModel>(
+          ErrorItem(
             title: 'No session',
             code: 'ERR_NOT_SIGNED_IN',
             description: 'There is no active session',
@@ -144,6 +144,6 @@ class FakeRepositoryAuth implements RepositoryAuth {
   @override
   Future<Either<ErrorItem, bool>> isSignedIn() async {
     isSignedInCalls++;
-    return nextIsSignedInResult ?? Right<ErrorItem, bool>(false);
+    return nextIsSignedInResult ?? const Right<ErrorItem, bool>(false);
   }
 }

--- a/test/src/repositories/repository_auth_impl_test.dart
+++ b/test/src/repositories/repository_auth_impl_test.dart
@@ -160,8 +160,8 @@ class _StubGateway implements GatewayAuth {
   @override
   Future<Either<ErrorItem, Map<String, dynamic>>> logInWithGoogle() async {
     return google ??
-        Right<ErrorItem, Map<String, dynamic>>(
-          const <String, dynamic>{'id': 'g', 'email': 'g@x.com'},
+        const Right<ErrorItem, Map<String, dynamic>>(
+          <String, dynamic>{'id': 'g', 'email': 'g@x.com'},
         );
   }
 
@@ -198,16 +198,16 @@ class _StubGateway implements GatewayAuth {
     Map<String, dynamic> sessionJson,
   ) async {
     return logout ??
-        Right<ErrorItem, Map<String, dynamic>>(
-          const <String, dynamic>{'ok': true},
+        const Right<ErrorItem, Map<String, dynamic>>(
+          <String, dynamic>{'ok': true},
         );
   }
 
   @override
   Future<Either<ErrorItem, Map<String, dynamic>>> getCurrentUser() async {
     return current ??
-        Right<ErrorItem, Map<String, dynamic>>(
-          const <String, dynamic>{'id': 'id', 'email': 'a@b.com'},
+        const Right<ErrorItem, Map<String, dynamic>>(
+          <String, dynamic>{'id': 'id', 'email': 'a@b.com'},
         );
     // Para simular "no session" como error, retorna Left
   }
@@ -215,8 +215,8 @@ class _StubGateway implements GatewayAuth {
   @override
   Future<Either<ErrorItem, Map<String, dynamic>>> isSignedIn() async {
     return signedIn ??
-        Right<ErrorItem, Map<String, dynamic>>(
-          const <String, dynamic>{'isSignedIn': true},
+        const Right<ErrorItem, Map<String, dynamic>>(
+          <String, dynamic>{'isSignedIn': true},
         );
   }
 
@@ -253,32 +253,32 @@ void main() {
     test('StubGateway acepta todos los parámetros opcionales (silencia lints)',
         () {
       final _StubGateway g = _StubGateway(
-        signIn: Right<ErrorItem, Map<String, dynamic>>(
-          const <String, dynamic>{'id': 's', 'email': 's@x.com'},
+        signIn: const Right<ErrorItem, Map<String, dynamic>>(
+          <String, dynamic>{'id': 's', 'email': 's@x.com'},
         ),
-        login: Right<ErrorItem, Map<String, dynamic>>(
-          const <String, dynamic>{'id': 'l', 'email': 'l@x.com'},
+        login: const Right<ErrorItem, Map<String, dynamic>>(
+          <String, dynamic>{'id': 'l', 'email': 'l@x.com'},
         ),
-        google: Right<ErrorItem, Map<String, dynamic>>(
-          const <String, dynamic>{'id': 'g', 'email': 'g@x.com'},
+        google: const Right<ErrorItem, Map<String, dynamic>>(
+          <String, dynamic>{'id': 'g', 'email': 'g@x.com'},
         ),
-        silent: Right<ErrorItem, Map<String, dynamic>>(
-          const <String, dynamic>{'id': 'z', 'email': 'z@x.com'},
+        silent: const Right<ErrorItem, Map<String, dynamic>>(
+          <String, dynamic>{'id': 'z', 'email': 'z@x.com'},
         ),
-        refresh: Right<ErrorItem, Map<String, dynamic>>(
-          const <String, dynamic>{'id': 'r', 'email': 'r@x.com'},
+        refresh: const Right<ErrorItem, Map<String, dynamic>>(
+          <String, dynamic>{'id': 'r', 'email': 'r@x.com'},
         ),
-        recover: Right<ErrorItem, Map<String, dynamic>>(
-          const <String, dynamic>{'ok': true},
+        recover: const Right<ErrorItem, Map<String, dynamic>>(
+          <String, dynamic>{'ok': true},
         ),
-        logout: Right<ErrorItem, Map<String, dynamic>>(
-          const <String, dynamic>{'ok': true},
+        logout: const Right<ErrorItem, Map<String, dynamic>>(
+          <String, dynamic>{'ok': true},
         ),
-        current: Right<ErrorItem, Map<String, dynamic>>(
-          const <String, dynamic>{'id': 'c', 'email': 'c@x.com'},
+        current: const Right<ErrorItem, Map<String, dynamic>>(
+          <String, dynamic>{'id': 'c', 'email': 'c@x.com'},
         ),
-        signedIn: Right<ErrorItem, Map<String, dynamic>>(
-          const <String, dynamic>{'isSignedIn': true},
+        signedIn: const Right<ErrorItem, Map<String, dynamic>>(
+          <String, dynamic>{'isSignedIn': true},
         ),
         authStream:
             const Stream<Either<ErrorItem, Map<String, dynamic>?>>.empty(),
@@ -288,7 +288,7 @@ void main() {
 
     test('logInUserAndPassword → Right(UserModel)', () async {
       final GatewayAuth gw = _StubGateway(
-        login: Right<ErrorItem, Map<String, dynamic>>(const <String, dynamic>{
+        login: const Right<ErrorItem, Map<String, dynamic>>(<String, dynamic>{
           'id': 'u1',
           'email': 'a@b.com',
           'jwt': <String, dynamic>{'accessToken': 't'},
@@ -310,8 +310,8 @@ void main() {
     test('logInWithGoogle → Right(UserModel)', () async {
       final RepositoryAuth repo = RepositoryAuthImpl(
         gateway: _StubGateway(
-          google: Right<ErrorItem, Map<String, dynamic>>(
-            const <String, dynamic>{'id': 'g', 'email': 'g@x.com'},
+          google: const Right<ErrorItem, Map<String, dynamic>>(
+            <String, dynamic>{'id': 'g', 'email': 'g@x.com'},
           ),
         ),
         errorMapper: const _FakeErrorMapper(),
@@ -350,8 +350,8 @@ void main() {
     test('getCurrentUser → Right(UserModel)', () async {
       final RepositoryAuth repo = RepositoryAuthImpl(
         gateway: _StubGateway(
-          current: Right<ErrorItem, Map<String, dynamic>>(
-            const <String, dynamic>{'id': 'id', 'email': 'a@b.com'},
+          current: const Right<ErrorItem, Map<String, dynamic>>(
+            <String, dynamic>{'id': 'id', 'email': 'a@b.com'},
           ),
         ),
         errorMapper: const _FakeErrorMapper(),
@@ -366,8 +366,8 @@ void main() {
     test('isSignedIn → Right(bool)', () async {
       final RepositoryAuth repo = RepositoryAuthImpl(
         gateway: _StubGateway(
-          signedIn: Right<ErrorItem, Map<String, dynamic>>(
-            const <String, dynamic>{'isSignedIn': false},
+          signedIn: const Right<ErrorItem, Map<String, dynamic>>(
+            <String, dynamic>{'isSignedIn': false},
           ),
         ),
         errorMapper: const _FakeErrorMapper(),
@@ -384,8 +384,8 @@ void main() {
     test('payload error (ok:false) → Left en signIn', () async {
       final RepositoryAuth repo = RepositoryAuthImpl(
         gateway: _StubGateway(
-          signIn: Right<ErrorItem, Map<String, dynamic>>(
-            const <String, dynamic>{'ok': false, 'message': 'nope'},
+          signIn: const Right<ErrorItem, Map<String, dynamic>>(
+            <String, dynamic>{'ok': false, 'message': 'nope'},
           ),
         ),
         errorMapper: const _FakeErrorMapper(),
@@ -396,8 +396,8 @@ void main() {
     test('payload inválido (ok:false) → Left', () async {
       final RepositoryAuth repo = RepositoryAuthImpl(
         gateway: _StubGateway(
-          login: Right<ErrorItem, Map<String, dynamic>>(
-            const <String, dynamic>{'ok': false, 'message': 'invalid'},
+          login: const Right<ErrorItem, Map<String, dynamic>>(
+            <String, dynamic>{'ok': false, 'message': 'invalid'},
           ),
         ),
         errorMapper: const _FakeErrorMapper(),
@@ -408,8 +408,8 @@ void main() {
     test('isSignedIn payload error → Left', () async {
       final RepositoryAuth repo = RepositoryAuthImpl(
         gateway: _StubGateway(
-          signedIn: Right<ErrorItem, Map<String, dynamic>>(
-            const <String, dynamic>{'ok': false},
+          signedIn: const Right<ErrorItem, Map<String, dynamic>>(
+            <String, dynamic>{'ok': false},
           ),
         ),
         errorMapper: const _FakeErrorMapper(),
@@ -420,8 +420,8 @@ void main() {
     test('malformed json (payload inválido) → Left vía mapper', () async {
       final RepositoryAuth repo = RepositoryAuthImpl(
         gateway: _StubGateway(
-          login: Right<ErrorItem, Map<String, dynamic>>(
-            const <String, dynamic>{'ok': false, 'message': 'invalid'},
+          login: const Right<ErrorItem, Map<String, dynamic>>(
+            <String, dynamic>{'ok': false, 'message': 'invalid'},
           ),
         ),
         errorMapper: const _FakeErrorMapper(),
@@ -444,10 +444,10 @@ void main() {
       final StreamSubscription<Either<ErrorItem, UserModel?>> sub =
           repo.authStateChanges().listen(emissions.add);
 
-      ctrl.add(Right<ErrorItem, Map<String, dynamic>?>(null));
+      ctrl.add(const Right<ErrorItem, Map<String, dynamic>?>(null));
       ctrl.add(
-        Right<ErrorItem, Map<String, dynamic>?>(
-          const <String, dynamic>{'id': 'id', 'email': 'a@b.com'},
+        const Right<ErrorItem, Map<String, dynamic>?>(
+          <String, dynamic>{'id': 'id', 'email': 'a@b.com'},
         ),
       );
       await Future<void>.delayed(const Duration(milliseconds: 1));
@@ -480,8 +480,8 @@ void main() {
       });
 
       ctrl.add(
-        Right<ErrorItem, Map<String, dynamic>?>(
-          const <String, dynamic>{'ok': false},
+        const Right<ErrorItem, Map<String, dynamic>?>(
+          <String, dynamic>{'ok': false},
         ),
       );
       await seenLeft.future;
@@ -493,7 +493,7 @@ void main() {
       final Stream<Either<ErrorItem, Map<String, dynamic>?>> s =
           Stream<Either<ErrorItem, Map<String, dynamic>?>>.fromIterable(
         <Either<ErrorItem, Map<String, dynamic>?>>[
-          Left<ErrorItem, Map<String, dynamic>?>(
+          const Left<ErrorItem, Map<String, dynamic>?>(
             SessionErrorItems.networkUnavailable,
           ),
         ],
@@ -517,7 +517,7 @@ void main() {
         () async {
       // El gateway entrega JSON válido; onOk devuelve el mismo UserModel (identidad).
       final GatewayAuth gw = _StubGateway(
-        signIn: Right<ErrorItem, Map<String, dynamic>>(const <String, dynamic>{
+        signIn: const Right<ErrorItem, Map<String, dynamic>>(<String, dynamic>{
           'id': 'u1',
           'email': 'onok@x.com',
           'jwt': <String, dynamic>{'accessToken': 't'},
@@ -544,8 +544,8 @@ void main() {
         () async {
       final RepositoryAuth repo = RepositoryAuthImpl(
         gateway: _StubGateway(
-          recover: Right<ErrorItem, Map<String, dynamic>>(
-            const <String, dynamic>{'ok': false, 'message': 'invalid'},
+          recover: const Right<ErrorItem, Map<String, dynamic>>(
+            <String, dynamic>{'ok': false, 'message': 'invalid'},
           ),
         ),
         errorMapper: const _FakeErrorMapper(), // detecta ok:false

--- a/test/src/repositories/repository_connectivity_impl_test.dart
+++ b/test/src/repositories/repository_connectivity_impl_test.dart
@@ -33,24 +33,24 @@ class _StubGatewayPayloadError implements GatewayConnectivity {
   final ConnectivityModel _curr;
   @override
   Future<Either<ErrorItem, Map<String, dynamic>>> snapshot() async =>
-      Right<ErrorItem, Map<String, dynamic>>(const <String, dynamic>{
+      const Right<ErrorItem, Map<String, dynamic>>(<String, dynamic>{
         'error': <String, String>{'code': 'MY_ERR', 'message': 'bad'},
       });
   @override
   Stream<Either<ErrorItem, Map<String, dynamic>>> watch() async* {
-    yield Right<ErrorItem, Map<String, dynamic>>(const <String, dynamic>{
+    yield const Right<ErrorItem, Map<String, dynamic>>(<String, dynamic>{
       'error': <String, String>{'code': 'MY_ERR', 'message': 'bad'},
     });
   }
 
   @override
   Future<Either<ErrorItem, Map<String, dynamic>>> checkType() async =>
-      Right<ErrorItem, Map<String, dynamic>>(const <String, dynamic>{
+      const Right<ErrorItem, Map<String, dynamic>>(<String, dynamic>{
         'error': <String, String>{'code': 'MY_ERR', 'message': 'bad'},
       });
   @override
   Future<Either<ErrorItem, Map<String, dynamic>>> checkSpeed() async =>
-      Right<ErrorItem, Map<String, dynamic>>(const <String, dynamic>{
+      const Right<ErrorItem, Map<String, dynamic>>(<String, dynamic>{
         'error': <String, String>{'code': 'MY_ERR', 'message': 'bad'},
       });
   @override

--- a/test/src/repositories/repository_http_request_impl_test.dart
+++ b/test/src/repositories/repository_http_request_impl_test.dart
@@ -213,7 +213,7 @@ void main() {
 
         final _FakeGatewayHttpRequest fakeGateway = _FakeGatewayHttpRequest()
           ..forcedGetResult =
-              Left<ErrorItem, Map<String, dynamic>>(gatewayError);
+              const Left<ErrorItem, Map<String, dynamic>>(gatewayError);
 
         final RepositoryHttpRequestImpl repository =
             RepositoryHttpRequestImpl(fakeGateway);
@@ -309,7 +309,7 @@ void main() {
 
         final _FakeGatewayHttpRequest fakeGateway = _FakeGatewayHttpRequest()
           ..forcedPostResult =
-              Left<ErrorItem, Map<String, dynamic>>(gatewayError);
+              const Left<ErrorItem, Map<String, dynamic>>(gatewayError);
 
         final RepositoryHttpRequestImpl repository =
             RepositoryHttpRequestImpl(fakeGateway);
@@ -426,7 +426,7 @@ void main() {
 
         final _FakeGatewayHttpRequest fakeGateway = _FakeGatewayHttpRequest()
           ..forcedPutResult =
-              Left<ErrorItem, Map<String, dynamic>>(gatewayError);
+              const Left<ErrorItem, Map<String, dynamic>>(gatewayError);
 
         final RepositoryHttpRequestImpl repository =
             RepositoryHttpRequestImpl(fakeGateway);
@@ -510,7 +510,7 @@ void main() {
 
         final _FakeGatewayHttpRequest fakeGateway = _FakeGatewayHttpRequest()
           ..forcedDeleteResult =
-              Left<ErrorItem, Map<String, dynamic>>(gatewayError);
+              const Left<ErrorItem, Map<String, dynamic>>(gatewayError);
 
         final RepositoryHttpRequestImpl repository =
             RepositoryHttpRequestImpl(fakeGateway);

--- a/test/src/repositories/repository_ws_database_impl_test.dart
+++ b/test/src/repositories/repository_ws_database_impl_test.dart
@@ -91,7 +91,9 @@ class _GatewayFake implements GatewayWsDatabase {
   Future<Either<ErrorItem, Map<String, dynamic>>> read(String docId) async {
     final Map<String, dynamic>? json = _store[docId];
     if (json == null) {
-      return Left<ErrorItem, Map<String, dynamic>>(DatabaseErrorItems.notFound);
+      return const Left<ErrorItem, Map<String, dynamic>>(
+        DatabaseErrorItems.notFound,
+      );
     }
     return Right<ErrorItem, Map<String, dynamic>>(
       Map<String, dynamic>.from(json),
@@ -123,9 +125,9 @@ class _GatewayFake implements GatewayWsDatabase {
     }
     _store.remove(docId);
     _docCtrls[docId]?.add(
-      Left<ErrorItem, Map<String, dynamic>>(DatabaseErrorItems.notFound),
+      const Left<ErrorItem, Map<String, dynamic>>(DatabaseErrorItems.notFound),
     );
-    return Right<ErrorItem, Unit>(Unit.value);
+    return const Right<ErrorItem, Unit>(Unit.value);
   }
 
   @override


### PR DESCRIPTION

### Changed
- Added a `const` constructor to the `Either` base class and to its concrete variants:
  - `Left`
  - `Right`
- Enabled compile-time constant creation for `Either` values when the contained value is also constant.
- Applied the resulting linter-driven `const` updates across the package.

### Quality
- Completed 189 minor `prefer_const_constructors` updates suggested by the linter.
- Verified that the package remains stable after the const migration.

### Migration note
- This change is backward compatible.
- Consumers using strict lint rules may now receive additional `prefer_const_constructors` suggestions where `Left` or `Right` instances can be declared as `const`.
- No behavioral changes were introduced for `when`, `fold`, `isLeft`, `isRight`, equality, `hashCode`, or `toString`.
