### PR TITLE
feat(i18n): add language and localized text models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Recent entries aim to follow a normalized structure. Older historical entries may preserve some original headings where reclassification would risk changing the original intent.
 
+## [1.43.0] - 2026-08-17
+
+### Added
+
+* Internationalization domain primitives:
+
+  * Added `ModelLanguage` with deterministic language, script and region representation, canonical language tags, structural equality and stable `hashCode`.
+  * Added normalized JSON round-trip support for `ModelLanguage`, including safe fallback to `und` for missing or empty language codes.
+  * Added ready-to-use language presets for common regional configurations.
+  * Added `ModelLocalizedText` with immutable localized translations through defensive copying and unmodifiable maps.
+  * Added explicit fallback-language support using `ModelLanguage.undetermined` when no fallback is declared.
+  * Added deterministic JSON round-trip support for localized text using stable public JSON keys and nested `ModelLanguage` serialization.
+  * Exported the new internationalization models through the main `jocaagura_domain` library.
+
+### Changed
+
+* Updated analyzer exclusions for generated Flutter build and platform directories in the package and example project.
+* Updated `GatewayWsDatabaseImpl` read-after-write flow to await the authoritative read inside the existing error-handling boundary.
+
+### Tests
+
+* Added comprehensive unit tests for language normalization, canonical tags, presets, equality, hashing, JSON serialization/deserialization and round-trip behavior.
+* Added tests for localized-text defensive copying, unmodifiable translations, fallback behavior, structural equality and deterministic JSON handling.
+* Achieved 100% line coverage for `ModelLanguage`.
+* Achieved 100% line coverage for `ModelLocalizedText`.
+
+
 ## [1.42.0] - 2026-06-15
 
 ### Fixed

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -27,6 +27,13 @@ analyzer:
     - "bin/cache/**"
       # Ignore protoc generated files
     - "dev/conductor/lib/proto/*"
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 
 linter:
   rules:

--- a/example/analysis_options.yaml
+++ b/example/analysis_options.yaml
@@ -27,6 +27,13 @@ analyzer:
     - "bin/cache/**"
       # Ignore protoc generated files
     - "dev/conductor/lib/proto/*"
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 
 linter:
   rules:

--- a/lib/domain/internationalization/model_language.dart
+++ b/lib/domain/internationalization/model_language.dart
@@ -1,0 +1,355 @@
+part of '../../jocaagura_domain.dart';
+
+/// Creates a language configuration.
+///
+/// [languageCode] must not be empty and should use a valid language code
+/// such as `es`, `en`, or `pt`.
+///
+/// [scriptCode] optionally identifies the writing system, such as `Hans`
+/// or `Hant`.
+///
+/// [regionCode] optionally identifies a region, such as `CO`, `US`,
+/// or `BR`.
+///
+/// Usage recommendation:
+///
+/// Prefer [fromJson] when creating a language from external or untrusted data,
+/// because it normalizes the input and falls back to [undeterminedCode] when
+/// `languageCode` is missing or empty.
+///
+/// When using this constructor directly, provide a non-empty [languageCode].
+/// The constructor uses an assertion to detect empty values during development,
+/// but assertions are not guaranteed to run in production builds.
+///
+/// Use [undetermined] explicitly when no language can be determined.
+/// Example:
+///
+/// ```dart
+/// const ModelLanguage language = ModelLanguage.spanishColombia;
+///
+/// const ModelLanguage equivalent = ModelLanguage(
+///   languageCode: 'es',
+///   regionCode: 'CO',
+/// );
+///
+/// void main() {
+///   assert(language == equivalent);
+///   assert(language.languageCode == 'es');
+///   assert(language.regionCode == 'CO');
+/// }
+/// ```
+@immutable
+class ModelLanguage {
+  /// Creates a language configuration.
+  ///
+  /// [languageCode] must not be empty and should use a valid language code
+  /// such as `es`, `en`, or `pt`.
+  ///
+  /// [scriptCode] optionally identifies the writing system, such as `Hans`
+  /// or `Hant`.
+  ///
+  /// [regionCode] optionally identifies a region, such as `CO`, `US`,
+  /// or `BR`.
+  /// Usage recommendation:
+  ///
+  /// Prefer [fromJson] when creating a language from external or untrusted data,
+  /// because it normalizes the input and falls back to [undeterminedCode] when
+  /// `languageCode` is missing or empty.
+  ///
+  /// When using this constructor directly, provide a non-empty [languageCode].
+  /// The constructor uses an assertion to detect empty values during development,
+  /// but assertions are not guaranteed to run in production builds.
+  ///
+  /// Use [undetermined] explicitly when no language can be determined.
+  const ModelLanguage({
+    required this.languageCode,
+    this.scriptCode = '',
+    this.regionCode = '',
+  }) : assert(languageCode != '');
+
+  /// Creates a [ModelLanguage] from a JSON map.
+  ///
+  /// External values are normalized before entering the domain:
+  ///
+  /// - `languageCode` is trimmed and converted to lowercase.
+  /// - `scriptCode` is trimmed and normalized to title case.
+  /// - `regionCode` is trimmed and converted to uppercase.
+  /// - An empty or missing `languageCode` falls back to [undeterminedCode].
+  ///
+  /// Example:
+  ///
+  /// ```dart
+  /// void main() {
+  ///   final ModelLanguage language = ModelLanguage.fromJson(
+  ///     <String, dynamic>{
+  ///       'languageCode': 'ES',
+  ///       'scriptCode': '',
+  ///       'regionCode': 'co',
+  ///     },
+  ///   );
+  ///
+  ///   assert(language == ModelLanguage.spanishColombia);
+  /// }
+  /// ```
+  factory ModelLanguage.fromJson(Map<String, dynamic> json) {
+    final String rawLanguageCode =
+        Utils.getStringFromDynamic(json[languageCodeKey]).trim();
+
+    final String rawScriptCode =
+        Utils.getStringFromDynamic(json[scriptCodeKey]).trim();
+
+    final String rawRegionCode =
+        Utils.getStringFromDynamic(json[regionCodeKey]).trim();
+
+    return ModelLanguage(
+      languageCode: rawLanguageCode.isEmpty
+          ? undeterminedCode
+          : rawLanguageCode.toLowerCase(),
+      scriptCode: _normalizeScriptCode(rawScriptCode),
+      regionCode: rawRegionCode.toUpperCase(),
+    );
+  }
+
+  /// JSON key for [languageCode].
+  static const String languageCodeKey = 'languageCode';
+
+  /// JSON key for [scriptCode].
+  static const String scriptCodeKey = 'scriptCode';
+
+  /// JSON key for [regionCode].
+  static const String regionCodeKey = 'regionCode';
+
+  /// Language code used when the language cannot be determined.
+  static const String undeterminedCode = 'und';
+
+  /// Undetermined language.
+  static const ModelLanguage undetermined = ModelLanguage(
+    languageCode: undeterminedCode,
+  );
+
+  /// Spanish used in Colombia.
+  static const ModelLanguage spanishColombia = ModelLanguage(
+    languageCode: 'es',
+    regionCode: 'CO',
+  );
+
+  /// Spanish used in Mexico.
+  static const ModelLanguage spanishMexico = ModelLanguage(
+    languageCode: 'es',
+    regionCode: 'MX',
+  );
+
+  /// Spanish used in Spain.
+  static const ModelLanguage spanishSpain = ModelLanguage(
+    languageCode: 'es',
+    regionCode: 'ES',
+  );
+
+  /// Spanish used in Argentina.
+  static const ModelLanguage spanishArgentina = ModelLanguage(
+    languageCode: 'es',
+    regionCode: 'AR',
+  );
+
+  /// Spanish used in Chile.
+  static const ModelLanguage spanishChile = ModelLanguage(
+    languageCode: 'es',
+    regionCode: 'CL',
+  );
+
+  /// Spanish used in Peru.
+  static const ModelLanguage spanishPeru = ModelLanguage(
+    languageCode: 'es',
+    regionCode: 'PE',
+  );
+
+  /// English used in the United States.
+  static const ModelLanguage englishUnitedStates = ModelLanguage(
+    languageCode: 'en',
+    regionCode: 'US',
+  );
+
+  /// English used in the United Kingdom.
+  static const ModelLanguage englishUnitedKingdom = ModelLanguage(
+    languageCode: 'en',
+    regionCode: 'GB',
+  );
+
+  /// English used in Canada.
+  static const ModelLanguage englishCanada = ModelLanguage(
+    languageCode: 'en',
+    regionCode: 'CA',
+  );
+
+  /// English used in Australia.
+  static const ModelLanguage englishAustralia = ModelLanguage(
+    languageCode: 'en',
+    regionCode: 'AU',
+  );
+
+  /// Portuguese used in Brazil.
+  static const ModelLanguage portugueseBrazil = ModelLanguage(
+    languageCode: 'pt',
+    regionCode: 'BR',
+  );
+
+  /// Portuguese used in Portugal.
+  static const ModelLanguage portuguesePortugal = ModelLanguage(
+    languageCode: 'pt',
+    regionCode: 'PT',
+  );
+
+  /// French used in France.
+  static const ModelLanguage frenchFrance = ModelLanguage(
+    languageCode: 'fr',
+    regionCode: 'FR',
+  );
+
+  /// German used in Germany.
+  static const ModelLanguage germanGermany = ModelLanguage(
+    languageCode: 'de',
+    regionCode: 'DE',
+  );
+
+  /// Italian used in Italy.
+  static const ModelLanguage italianItaly = ModelLanguage(
+    languageCode: 'it',
+    regionCode: 'IT',
+  );
+
+  /// Dutch used in the Netherlands.
+  static const ModelLanguage dutchNetherlands = ModelLanguage(
+    languageCode: 'nl',
+    regionCode: 'NL',
+  );
+
+  /// Japanese used in Japan.
+  static const ModelLanguage japaneseJapan = ModelLanguage(
+    languageCode: 'ja',
+    regionCode: 'JP',
+  );
+
+  /// Korean used in South Korea.
+  static const ModelLanguage koreanSouthKorea = ModelLanguage(
+    languageCode: 'ko',
+    regionCode: 'KR',
+  );
+
+  /// Simplified Chinese used in China.
+  static const ModelLanguage chineseChina = ModelLanguage(
+    languageCode: 'zh',
+    scriptCode: 'Hans',
+    regionCode: 'CN',
+  );
+
+  /// Traditional Chinese used in Taiwan.
+  static const ModelLanguage chineseTaiwan = ModelLanguage(
+    languageCode: 'zh',
+    scriptCode: 'Hant',
+    regionCode: 'TW',
+  );
+
+  /// Hindi used in India.
+  static const ModelLanguage hindiIndia = ModelLanguage(
+    languageCode: 'hi',
+    regionCode: 'IN',
+  );
+
+  /// Indonesian used in Indonesia.
+  static const ModelLanguage indonesianIndonesia = ModelLanguage(
+    languageCode: 'id',
+    regionCode: 'ID',
+  );
+
+  /// Turkish used in Türkiye.
+  static const ModelLanguage turkishTurkey = ModelLanguage(
+    languageCode: 'tr',
+    regionCode: 'TR',
+  );
+
+  /// Polish used in Poland.
+  static const ModelLanguage polishPoland = ModelLanguage(
+    languageCode: 'pl',
+    regionCode: 'PL',
+  );
+
+  /// Swedish used in Sweden.
+  static const ModelLanguage swedishSweden = ModelLanguage(
+    languageCode: 'sv',
+    regionCode: 'SE',
+  );
+
+  /// Norwegian used in Norway.
+  static const ModelLanguage norwegianNorway = ModelLanguage(
+    languageCode: 'no',
+    regionCode: 'NO',
+  );
+
+  /// Language identifier.
+  final String languageCode;
+
+  /// Optional writing system identifier.
+  final String scriptCode;
+
+  /// Optional region identifier.
+  final String regionCode;
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        other is ModelLanguage &&
+            languageCode == other.languageCode &&
+            scriptCode == other.scriptCode &&
+            regionCode == other.regionCode;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        languageCode,
+        scriptCode,
+        regionCode,
+      );
+
+  /// Converts this language configuration into a JSON map.
+  ///
+  /// All fields are included to keep the serialized representation
+  /// deterministic.
+  ///
+  /// Example:
+  ///
+  /// ```dart
+  /// void main() {
+  ///   final Map<String, dynamic> json =
+  ///       ModelLanguage.spanishColombia.toJson();
+  ///
+  ///   assert(json['languageCode'] == 'es');
+  ///   assert(json['scriptCode'] == '');
+  ///   assert(json['regionCode'] == 'CO');
+  /// }
+  /// ```
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      languageCodeKey: languageCode,
+      scriptCodeKey: scriptCode,
+      regionCodeKey: regionCode,
+    };
+  }
+
+  static String _normalizeScriptCode(String value) {
+    if (value.isEmpty) {
+      return '';
+    }
+
+    final String normalized = value.toLowerCase();
+
+    return '${normalized[0].toUpperCase()}${normalized.substring(1)}';
+  }
+
+  String get canonicalTag {
+    return <String>[
+      languageCode,
+      if (scriptCode.isNotEmpty) scriptCode,
+      if (regionCode.isNotEmpty) regionCode,
+    ].join('-');
+  }
+}

--- a/lib/domain/internationalization/model_localized_text.dart
+++ b/lib/domain/internationalization/model_localized_text.dart
@@ -1,0 +1,246 @@
+part of '../../jocaagura_domain.dart';
+
+/// Represents text translated into one or more languages.
+///
+/// [translations] contains the available localized values indexed by
+/// [ModelLanguage].
+///
+/// [fallbackLanguage] identifies the preferred fallback language when one has
+/// been explicitly declared. [ModelLanguage.undetermined] represents the
+/// absence of a specific fallback.
+///
+/// The provided translations are defensively copied into an unmodifiable map,
+/// preventing external mutations from changing the model after construction.
+///
+/// Example:
+///
+/// ```dart
+/// void main() {
+///   final ModelLocalizedText text = ModelLocalizedText(
+///     translations: <ModelLanguage, String>{
+///       ModelLanguage.spanishColombia: 'Hola',
+///       ModelLanguage.englishUnitedStates: 'Hello',
+///     },
+///     fallbackLanguage: ModelLanguage.spanishColombia,
+///   );
+///
+///   assert(
+///     text.translations[ModelLanguage.spanishColombia] == 'Hola',
+///   );
+/// }
+/// ```
+@immutable
+class ModelLocalizedText {
+  /// Creates localized text from the provided [translations].
+  ///
+  /// The input map is defensively copied and exposed as an unmodifiable map.
+  ///
+  /// [fallbackLanguage] defaults to [ModelLanguage.undetermined], meaning that
+  /// no explicit fallback language has been declared.
+  ModelLocalizedText({
+    required Map<ModelLanguage, String> translations,
+    this.fallbackLanguage = ModelLanguage.undetermined,
+  }) : translations = Map<ModelLanguage, String>.unmodifiable(translations);
+
+  /// Creates a [ModelLocalizedText] from a JSON map.
+  ///
+  /// Invalid or missing external values are normalized deterministically:
+  ///
+  /// - Missing or invalid `translations` become an empty map.
+  /// - Missing or invalid translation languages become
+  ///   [ModelLanguage.undetermined].
+  /// - Missing or `null` translation text becomes an empty string.
+  /// - Missing or invalid `fallbackLanguage` becomes
+  ///   [ModelLanguage.undetermined].
+  /// - Language normalization is delegated to [ModelLanguage.fromJson].
+  ///
+  /// When multiple translation entries resolve to the same [ModelLanguage],
+  /// the last entry wins.
+  ///
+  /// Example:
+  ///
+  /// ```dart
+  /// void main() {
+  ///   final ModelLocalizedText text = ModelLocalizedText.fromJson(
+  ///     <String, dynamic>{
+  ///       'translations': <Map<String, dynamic>>[
+  ///         <String, dynamic>{
+  ///           'language': <String, dynamic>{
+  ///             'languageCode': 'ES',
+  ///             'regionCode': 'co',
+  ///           },
+  ///           'text': 'Hola',
+  ///         },
+  ///       ],
+  ///       'fallbackLanguage': <String, dynamic>{
+  ///         'languageCode': 'es',
+  ///         'regionCode': 'CO',
+  ///       },
+  ///     },
+  ///   );
+  ///
+  ///   assert(
+  ///     text.translations[ModelLanguage.spanishColombia] == 'Hola',
+  ///   );
+  ///   assert(
+  ///     text.fallbackLanguage == ModelLanguage.spanishColombia,
+  ///   );
+  /// }
+  /// ```
+  factory ModelLocalizedText.fromJson(Map<String, dynamic> json) {
+    final List<Map<String, dynamic>> rawTranslations =
+        Utils.listFromDynamic(json[translationsKey]);
+
+    final Map<ModelLanguage, String> translations = <ModelLanguage, String>{};
+
+    for (final Map<String, dynamic> rawTranslation in rawTranslations) {
+      final ModelLanguage language = ModelLanguage.fromJson(
+        Utils.mapFromDynamic(
+          rawTranslation[languageKey],
+        ),
+      );
+
+      final String text = Utils.getStringFromDynamic(
+        rawTranslation[textKey],
+      );
+
+      translations[language] = text;
+    }
+
+    final ModelLanguage fallbackLanguage = ModelLanguage.fromJson(
+      Utils.mapFromDynamic(
+        json[fallbackLanguageKey],
+      ),
+    );
+
+    return ModelLocalizedText(
+      translations: translations,
+      fallbackLanguage: fallbackLanguage,
+    );
+  }
+
+  /// Available translations indexed by language.
+  final Map<ModelLanguage, String> translations;
+
+  /// Preferred fallback language.
+  ///
+  /// [ModelLanguage.undetermined] means that no explicit fallback has been
+  /// declared.
+  final ModelLanguage fallbackLanguage;
+
+  /// JSON key for [translations].
+  static const String translationsKey = 'translations';
+
+  /// JSON key for [fallbackLanguage].
+  static const String fallbackLanguageKey = 'fallbackLanguage';
+
+  /// JSON key for the language of a translation entry.
+  static const String languageKey = 'language';
+
+  /// JSON key for the localized text of a translation entry.
+  static const String textKey = 'text';
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        other is ModelLocalizedText &&
+            fallbackLanguage == other.fallbackLanguage &&
+            _translationsAreEqual(
+              translations,
+              other.translations,
+            );
+  }
+
+  @override
+  int get hashCode {
+    final Iterable<int> translationHashes = translations.entries.map(
+      (MapEntry<ModelLanguage, String> entry) {
+        return Object.hash(
+          entry.key,
+          entry.value,
+        );
+      },
+    );
+
+    return Object.hash(
+      fallbackLanguage,
+      Object.hashAllUnordered(translationHashes),
+    );
+  }
+
+  static bool _translationsAreEqual(
+    Map<ModelLanguage, String> first,
+    Map<ModelLanguage, String> second,
+  ) {
+    if (identical(first, second)) {
+      return true;
+    }
+
+    if (first.length != second.length) {
+      return false;
+    }
+
+    for (final MapEntry<ModelLanguage, String> entry in first.entries) {
+      if (!second.containsKey(entry.key) || second[entry.key] != entry.value) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  /// Converts this localized text into a deterministic JSON map.
+  ///
+  /// Translation entries are sorted by [ModelLanguage.canonicalTag] before
+  /// serialization. This guarantees that equivalent models produce the same
+  /// JSON structure regardless of the original insertion order.
+  ///
+  /// Each language is serialized using [ModelLanguage.toJson].
+  ///
+  /// Example:
+  ///
+  /// ```dart
+  /// void main() {
+  ///   final ModelLocalizedText text = ModelLocalizedText(
+  ///     translations: <ModelLanguage, String>{
+  ///       ModelLanguage.spanishColombia: 'Hola',
+  ///       ModelLanguage.englishUnitedStates: 'Hello',
+  ///     },
+  ///     fallbackLanguage: ModelLanguage.spanishColombia,
+  ///   );
+  ///
+  ///   final Map<String, dynamic> json = text.toJson();
+  ///
+  ///   assert(json[ModelLocalizedText.translationsKey] is List<dynamic>);
+  ///   assert(
+  ///     json[ModelLocalizedText.fallbackLanguageKey]
+  ///         is Map<String, dynamic>,
+  ///   );
+  /// }
+  /// ```
+  Map<String, dynamic> toJson() {
+    final List<MapEntry<ModelLanguage, String>> sortedEntries =
+        translations.entries.toList()
+          ..sort(
+            (
+              MapEntry<ModelLanguage, String> first,
+              MapEntry<ModelLanguage, String> second,
+            ) {
+              return first.key.canonicalTag.compareTo(
+                second.key.canonicalTag,
+              );
+            },
+          );
+
+    return <String, dynamic>{
+      translationsKey: sortedEntries
+          .map(
+            (MapEntry<ModelLanguage, String> entry) => <String, dynamic>{
+              languageKey: entry.key.toJson(),
+              textKey: entry.value,
+            },
+          )
+          .toList(growable: false),
+      fallbackLanguageKey: fallbackLanguage.toJson(),
+    };
+  }
+}

--- a/lib/jocaagura_domain.dart
+++ b/lib/jocaagura_domain.dart
@@ -175,6 +175,8 @@ part 'domain/usecases/session/session_usecases.dart';
 part 'domain/usecases/session/sign_in_user_and_password_usecase.dart';
 part 'domain/usecases/session/watch_auth_state_changes_usecases.dart';
 part 'domain/usecases/usecase.dart';
+part 'domain/internationalization/model_language.dart';
+part 'domain/internationalization/model_localized_text.dart';
 part 'domain/user_model.dart';
 part 'domain/utils/money_utils.dart';
 part 'domain/vehicles/model_vehicle.dart';

--- a/lib/src/gateways/gateway_ws_database_impl.dart
+++ b/lib/src/gateways/gateway_ws_database_impl.dart
@@ -171,7 +171,7 @@ class GatewayWsDatabaseImpl implements GatewayWsDatabase {
         document: json,
       );
       if (_readAfterWrite) {
-        return read(docId); // authoritative
+        return await read(docId); // authoritative
       }
       return Right<ErrorItem, Map<String, dynamic>>(_withId(docId, json));
     } catch (e, s) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: jocaagura_domain
 description: "A package with domain models for all transversal applications"
 
-version: 1.42.0
+version: 1.43.0
 
 
 homepage: https://github.com/jocaagura/jocaagura_domain

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: jocaagura_domain
 description: "A package with domain models for all transversal applications"
 
-version: 1.43.0
+version: 1.44.0
 
 
 homepage: https://github.com/jocaagura/jocaagura_domain

--- a/test/domain/internationalization/model_language_test.dart
+++ b/test/domain/internationalization/model_language_test.dart
@@ -1,0 +1,704 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jocaagura_domain/jocaagura_domain.dart';
+
+void main() {
+  group('ModelLanguage constructor', () {
+    test(
+      'Given only languageCode When constructed Then optional codes default to empty strings',
+      () {
+        const ModelLanguage language = ModelLanguage(
+          languageCode: 'es',
+        );
+
+        expect(language.languageCode, 'es');
+        expect(language.scriptCode, '');
+        expect(language.regionCode, '');
+      },
+    );
+
+    test(
+      'Given all canonical codes When constructed Then values are preserved',
+      () {
+        const ModelLanguage language = ModelLanguage.chineseTaiwan;
+
+        expect(language.languageCode, 'zh');
+        expect(language.scriptCode, 'Hant');
+        expect(language.regionCode, 'TW');
+      },
+    );
+
+    test(
+      'Given an empty languageCode When constructed Then assertion fails',
+      () {
+        expect(
+          () => ModelLanguage(languageCode: ''),
+          throwsA(isA<AssertionError>()),
+        );
+      },
+    );
+  });
+
+  group('ModelLanguage serialization contract', () {
+    test(
+      'Given serialization constants When inspected Then JSON keys remain stable',
+      () {
+        expect(ModelLanguage.languageCodeKey, 'languageCode');
+        expect(ModelLanguage.scriptCodeKey, 'scriptCode');
+        expect(ModelLanguage.regionCodeKey, 'regionCode');
+      },
+    );
+
+    test(
+      'Given undeterminedCode When inspected Then it remains und',
+      () {
+        expect(ModelLanguage.undeterminedCode, 'und');
+      },
+    );
+
+    test(
+      'Given a language with all fields When toJson is called Then all fields are serialized',
+      () {
+        const ModelLanguage language = ModelLanguage.chineseTaiwan;
+
+        final Map<String, dynamic> json = language.toJson();
+
+        expect(
+          json,
+          <String, dynamic>{
+            'languageCode': 'zh',
+            'scriptCode': 'Hant',
+            'regionCode': 'TW',
+          },
+        );
+      },
+    );
+
+    test(
+      'Given empty optional fields When toJson is called Then all keys are still included',
+      () {
+        const ModelLanguage language = ModelLanguage(
+          languageCode: 'es',
+        );
+
+        final Map<String, dynamic> json = language.toJson();
+
+        expect(
+          json,
+          <String, dynamic>{
+            'languageCode': 'es',
+            'scriptCode': '',
+            'regionCode': '',
+          },
+        );
+      },
+    );
+
+    test(
+      'Given a serialized map When it is modified Then the language remains unchanged',
+      () {
+        const ModelLanguage language = ModelLanguage.spanishColombia;
+
+        final Map<String, dynamic> json = language.toJson();
+
+        json['languageCode'] = 'en';
+        json['regionCode'] = 'US';
+
+        expect(language, ModelLanguage.spanishColombia);
+
+        final Map<String, dynamic> secondJson = language.toJson();
+
+        expect(secondJson['languageCode'], 'es');
+        expect(secondJson['regionCode'], 'CO');
+      },
+    );
+  });
+
+  group('ModelLanguage fromJson normalization', () {
+    test(
+      'Given mixed-case and padded codes When parsed Then values are canonicalized',
+      () {
+        final ModelLanguage language = ModelLanguage.fromJson(
+          const <String, dynamic>{
+            'languageCode': ' ES ',
+            'scriptCode': ' hAnT ',
+            'regionCode': ' co ',
+          },
+        );
+
+        expect(language.languageCode, 'es');
+        expect(language.scriptCode, 'Hant');
+        expect(language.regionCode, 'CO');
+      },
+    );
+
+    test(
+      'Given an empty languageCode When parsed Then undetermined is used',
+      () {
+        final ModelLanguage language = ModelLanguage.fromJson(
+          const <String, dynamic>{
+            'languageCode': '',
+          },
+        );
+
+        expect(language, ModelLanguage.undetermined);
+      },
+    );
+
+    test(
+      'Given a whitespace languageCode When parsed Then undetermined is used',
+      () {
+        final ModelLanguage language = ModelLanguage.fromJson(
+          const <String, dynamic>{
+            'languageCode': '   ',
+            'scriptCode': '   ',
+            'regionCode': '   ',
+          },
+        );
+
+        expect(language, ModelLanguage.undetermined);
+      },
+    );
+
+    test(
+      'Given a missing languageCode When parsed Then undetermined is used',
+      () {
+        final ModelLanguage language = ModelLanguage.fromJson(
+          const <String, dynamic>{},
+        );
+
+        expect(language, ModelLanguage.undetermined);
+      },
+    );
+
+    test(
+      'Given null JSON values When parsed Then nulls are normalized safely',
+      () {
+        final ModelLanguage language = ModelLanguage.fromJson(
+          const <String, dynamic>{
+            'languageCode': null,
+            'scriptCode': null,
+            'regionCode': null,
+          },
+        );
+
+        expect(language, ModelLanguage.undetermined);
+      },
+    );
+
+    test(
+      'Given missing optional codes When parsed Then they remain empty',
+      () {
+        final ModelLanguage language = ModelLanguage.fromJson(
+          const <String, dynamic>{
+            'languageCode': 'EN',
+          },
+        );
+
+        expect(language.languageCode, 'en');
+        expect(language.scriptCode, '');
+        expect(language.regionCode, '');
+      },
+    );
+
+    test(
+      'Given a mixed-case script When parsed Then it is normalized to title case',
+      () {
+        final ModelLanguage language = ModelLanguage.fromJson(
+          const <String, dynamic>{
+            'languageCode': 'zh',
+            'scriptCode': 'hAnT',
+          },
+        );
+
+        expect(language.scriptCode, 'Hant');
+      },
+    );
+
+    test(
+      'Given a one-character script When parsed Then normalization remains safe',
+      () {
+        final ModelLanguage language = ModelLanguage.fromJson(
+          const <String, dynamic>{
+            'languageCode': 'x',
+            'scriptCode': 'h',
+          },
+        );
+
+        expect(language.scriptCode, 'H');
+      },
+    );
+
+    test(
+      'Given an input JSON map When parsed Then the original map is not mutated',
+      () {
+        final Map<String, dynamic> json = <String, dynamic>{
+          'languageCode': ' ES ',
+          'scriptCode': ' hAnT ',
+          'regionCode': ' co ',
+        };
+
+        final Map<String, dynamic> original = Map<String, dynamic>.from(json);
+
+        ModelLanguage.fromJson(json);
+
+        expect(json, original);
+      },
+    );
+  });
+
+  group('ModelLanguage JSON round trip', () {
+    test(
+      'Given a canonical language When serialized and parsed Then equality is preserved',
+      () {
+        const ModelLanguage original = ModelLanguage.chineseTaiwan;
+
+        final Map<String, dynamic> json = original.toJson();
+        final ModelLanguage restored = ModelLanguage.fromJson(json);
+
+        expect(restored, original);
+      },
+    );
+
+    test(
+      'Given a predefined language When serialized and parsed Then its contract is preserved',
+      () {
+        const ModelLanguage original = ModelLanguage.spanishColombia;
+
+        final ModelLanguage restored = ModelLanguage.fromJson(
+          original.toJson(),
+        );
+
+        expect(restored, original);
+      },
+    );
+  });
+
+  group('ModelLanguage equality', () {
+    test(
+      'Given the same reference When compared Then equality uses the identity path',
+      () {
+        const ModelLanguage language = ModelLanguage.spanishColombia;
+
+        const ModelLanguage sameReference = language;
+
+        expect(identical(language, sameReference), isTrue);
+        expect(language == sameReference, isTrue);
+      },
+    );
+
+    test(
+      'Given separate instances with equal fields When compared Then they are equal',
+      () {
+        const ModelLanguage first = ModelLanguage.spanishColombia;
+
+        const ModelLanguage second = ModelLanguage.spanishColombia;
+
+        expect(identical(first, second), isTrue);
+        expect(first, second);
+      },
+    );
+
+    test(
+      'Given an object of another type When compared Then equality is false',
+      () {
+        const ModelLanguage language = ModelLanguage(
+          languageCode: 'es',
+        );
+
+        // ignore: unrelated_type_equality_checks
+        expect(language == 'es', isFalse);
+      },
+    );
+
+    test(
+      'Given different languageCodes When compared Then equality is false',
+      () {
+        const ModelLanguage first = ModelLanguage.spanishColombia;
+
+        const ModelLanguage second = ModelLanguage(
+          languageCode: 'en',
+          regionCode: 'CO',
+        );
+
+        expect(first == second, isFalse);
+      },
+    );
+
+    test(
+      'Given different scriptCodes When compared Then equality is false',
+      () {
+        const ModelLanguage first = ModelLanguage.chineseChina;
+
+        const ModelLanguage second = ModelLanguage(
+          languageCode: 'zh',
+          scriptCode: 'Hant',
+          regionCode: 'CN',
+        );
+
+        expect(first == second, isFalse);
+      },
+    );
+
+    test(
+      'Given different regionCodes When compared Then equality is false',
+      () {
+        const ModelLanguage first = ModelLanguage.spanishColombia;
+
+        const ModelLanguage second = ModelLanguage.spanishMexico;
+
+        expect(first == second, isFalse);
+      },
+    );
+
+    test(
+      'Given equal instances When hashCode is calculated Then hashes are equal',
+      () {
+        const ModelLanguage first = ModelLanguage.chineseTaiwan;
+
+        const ModelLanguage second = ModelLanguage.chineseTaiwan;
+
+        expect(first, second);
+        expect(first.hashCode, second.hashCode);
+      },
+    );
+  });
+
+  group('ModelLanguage predefined languages', () {
+    final List<_LanguagePresetCase> cases = <_LanguagePresetCase>[
+      const _LanguagePresetCase(
+        name: 'undetermined',
+        language: ModelLanguage.undetermined,
+        languageCode: 'und',
+        regionCode: '',
+      ),
+      const _LanguagePresetCase(
+        name: 'spanishColombia',
+        language: ModelLanguage.spanishColombia,
+        languageCode: 'es',
+        regionCode: 'CO',
+      ),
+      const _LanguagePresetCase(
+        name: 'spanishMexico',
+        language: ModelLanguage.spanishMexico,
+        languageCode: 'es',
+        regionCode: 'MX',
+      ),
+      const _LanguagePresetCase(
+        name: 'spanishSpain',
+        language: ModelLanguage.spanishSpain,
+        languageCode: 'es',
+        regionCode: 'ES',
+      ),
+      const _LanguagePresetCase(
+        name: 'spanishArgentina',
+        language: ModelLanguage.spanishArgentina,
+        languageCode: 'es',
+        regionCode: 'AR',
+      ),
+      const _LanguagePresetCase(
+        name: 'spanishChile',
+        language: ModelLanguage.spanishChile,
+        languageCode: 'es',
+        regionCode: 'CL',
+      ),
+      const _LanguagePresetCase(
+        name: 'spanishPeru',
+        language: ModelLanguage.spanishPeru,
+        languageCode: 'es',
+        regionCode: 'PE',
+      ),
+      const _LanguagePresetCase(
+        name: 'englishUnitedStates',
+        language: ModelLanguage.englishUnitedStates,
+        languageCode: 'en',
+        regionCode: 'US',
+      ),
+      const _LanguagePresetCase(
+        name: 'englishUnitedKingdom',
+        language: ModelLanguage.englishUnitedKingdom,
+        languageCode: 'en',
+        regionCode: 'GB',
+      ),
+      const _LanguagePresetCase(
+        name: 'englishCanada',
+        language: ModelLanguage.englishCanada,
+        languageCode: 'en',
+        regionCode: 'CA',
+      ),
+      const _LanguagePresetCase(
+        name: 'englishAustralia',
+        language: ModelLanguage.englishAustralia,
+        languageCode: 'en',
+        regionCode: 'AU',
+      ),
+      const _LanguagePresetCase(
+        name: 'portugueseBrazil',
+        language: ModelLanguage.portugueseBrazil,
+        languageCode: 'pt',
+        regionCode: 'BR',
+      ),
+      const _LanguagePresetCase(
+        name: 'portuguesePortugal',
+        language: ModelLanguage.portuguesePortugal,
+        languageCode: 'pt',
+        regionCode: 'PT',
+      ),
+      const _LanguagePresetCase(
+        name: 'frenchFrance',
+        language: ModelLanguage.frenchFrance,
+        languageCode: 'fr',
+        regionCode: 'FR',
+      ),
+      const _LanguagePresetCase(
+        name: 'germanGermany',
+        language: ModelLanguage.germanGermany,
+        languageCode: 'de',
+        regionCode: 'DE',
+      ),
+      const _LanguagePresetCase(
+        name: 'italianItaly',
+        language: ModelLanguage.italianItaly,
+        languageCode: 'it',
+        regionCode: 'IT',
+      ),
+      const _LanguagePresetCase(
+        name: 'dutchNetherlands',
+        language: ModelLanguage.dutchNetherlands,
+        languageCode: 'nl',
+        regionCode: 'NL',
+      ),
+      const _LanguagePresetCase(
+        name: 'japaneseJapan',
+        language: ModelLanguage.japaneseJapan,
+        languageCode: 'ja',
+        regionCode: 'JP',
+      ),
+      const _LanguagePresetCase(
+        name: 'koreanSouthKorea',
+        language: ModelLanguage.koreanSouthKorea,
+        languageCode: 'ko',
+        regionCode: 'KR',
+      ),
+      const _LanguagePresetCase(
+        name: 'chineseChina',
+        language: ModelLanguage.chineseChina,
+        languageCode: 'zh',
+        scriptCode: 'Hans',
+        regionCode: 'CN',
+      ),
+      const _LanguagePresetCase(
+        name: 'chineseTaiwan',
+        language: ModelLanguage.chineseTaiwan,
+        languageCode: 'zh',
+        scriptCode: 'Hant',
+        regionCode: 'TW',
+      ),
+      const _LanguagePresetCase(
+        name: 'hindiIndia',
+        language: ModelLanguage.hindiIndia,
+        languageCode: 'hi',
+        regionCode: 'IN',
+      ),
+      const _LanguagePresetCase(
+        name: 'indonesianIndonesia',
+        language: ModelLanguage.indonesianIndonesia,
+        languageCode: 'id',
+        regionCode: 'ID',
+      ),
+      const _LanguagePresetCase(
+        name: 'turkishTurkey',
+        language: ModelLanguage.turkishTurkey,
+        languageCode: 'tr',
+        regionCode: 'TR',
+      ),
+      const _LanguagePresetCase(
+        name: 'polishPoland',
+        language: ModelLanguage.polishPoland,
+        languageCode: 'pl',
+        regionCode: 'PL',
+      ),
+      const _LanguagePresetCase(
+        name: 'swedishSweden',
+        language: ModelLanguage.swedishSweden,
+        languageCode: 'sv',
+        regionCode: 'SE',
+      ),
+      const _LanguagePresetCase(
+        name: 'norwegianNorway',
+        language: ModelLanguage.norwegianNorway,
+        languageCode: 'no',
+        regionCode: 'NO',
+      ),
+    ];
+
+    for (final _LanguagePresetCase testCase in cases) {
+      test(
+        'Given ${testCase.name} When inspected Then its canonical configuration is preserved',
+        () {
+          expect(
+            testCase.language.languageCode,
+            testCase.languageCode,
+          );
+          expect(
+            testCase.language.scriptCode,
+            testCase.scriptCode,
+          );
+          expect(
+            testCase.language.regionCode,
+            testCase.regionCode,
+          );
+        },
+      );
+    }
+  });
+  group('ModelLanguage canonicalTag', () {
+    test(
+      'Given only a languageCode When canonicalTag is read Then it returns the language code',
+      () {
+        const ModelLanguage language = ModelLanguage(
+          languageCode: 'es',
+        );
+
+        expect(language.canonicalTag, 'es');
+      },
+    );
+
+    test(
+      'Given languageCode and regionCode When canonicalTag is read Then it returns language-region',
+      () {
+        const ModelLanguage language = ModelLanguage.spanishColombia;
+
+        expect(language.canonicalTag, 'es-CO');
+      },
+    );
+
+    test(
+      'Given languageCode and scriptCode When canonicalTag is read Then it returns language-script',
+      () {
+        const ModelLanguage language = ModelLanguage(
+          languageCode: 'zh',
+          scriptCode: 'Hant',
+        );
+
+        expect(language.canonicalTag, 'zh-Hant');
+      },
+    );
+
+    test(
+      'Given languageCode scriptCode and regionCode When canonicalTag is read Then it returns the complete canonical tag',
+      () {
+        const ModelLanguage language = ModelLanguage.chineseTaiwan;
+
+        expect(language.canonicalTag, 'zh-Hant-TW');
+      },
+    );
+
+    test(
+      'Given the undetermined language When canonicalTag is read Then it returns und',
+      () {
+        expect(
+          ModelLanguage.undetermined.canonicalTag,
+          ModelLanguage.undeterminedCode,
+        );
+      },
+    );
+
+    test(
+      'Given a predefined language When canonicalTag is read Then it matches its canonical representation',
+      () {
+        expect(
+          ModelLanguage.spanishColombia.canonicalTag,
+          'es-CO',
+        );
+
+        expect(
+          ModelLanguage.chineseChina.canonicalTag,
+          'zh-Hans-CN',
+        );
+      },
+    );
+  });
+  group('ModelLanguage canonicalTag', () {
+    test(
+      'Given only a languageCode When canonicalTag is read Then it returns the language code',
+      () {
+        const ModelLanguage language = ModelLanguage(
+          languageCode: 'es',
+        );
+
+        expect(language.canonicalTag, 'es');
+      },
+    );
+
+    test(
+      'Given languageCode and regionCode When canonicalTag is read Then it returns language-region',
+      () {
+        const ModelLanguage language = ModelLanguage.spanishColombia;
+
+        expect(language.canonicalTag, 'es-CO');
+      },
+    );
+
+    test(
+      'Given languageCode and scriptCode When canonicalTag is read Then it returns language-script',
+      () {
+        const ModelLanguage language = ModelLanguage(
+          languageCode: 'zh',
+          scriptCode: 'Hant',
+        );
+
+        expect(language.canonicalTag, 'zh-Hant');
+      },
+    );
+
+    test(
+      'Given languageCode scriptCode and regionCode When canonicalTag is read Then it returns the complete canonical tag',
+      () {
+        const ModelLanguage language = ModelLanguage.chineseTaiwan;
+
+        expect(language.canonicalTag, 'zh-Hant-TW');
+      },
+    );
+
+    test(
+      'Given the undetermined language When canonicalTag is read Then it returns und',
+      () {
+        expect(
+          ModelLanguage.undetermined.canonicalTag,
+          ModelLanguage.undeterminedCode,
+        );
+      },
+    );
+
+    test(
+      'Given a predefined language When canonicalTag is read Then it matches its canonical representation',
+      () {
+        expect(
+          ModelLanguage.spanishColombia.canonicalTag,
+          'es-CO',
+        );
+
+        expect(
+          ModelLanguage.chineseChina.canonicalTag,
+          'zh-Hans-CN',
+        );
+      },
+    );
+  });
+}
+
+class _LanguagePresetCase {
+  const _LanguagePresetCase({
+    required this.name,
+    required this.language,
+    required this.languageCode,
+    required this.regionCode,
+    this.scriptCode = '',
+  });
+
+  final String name;
+  final ModelLanguage language;
+  final String languageCode;
+  final String scriptCode;
+  final String regionCode;
+}

--- a/test/domain/internationalization/model_localized_text_test.dart
+++ b/test/domain/internationalization/model_localized_text_test.dart
@@ -1,0 +1,1050 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jocaagura_domain/jocaagura_domain.dart';
+
+void main() {
+  group('constructor', () {
+    test(
+      'Given translations '
+      'When model is created without fallbackLanguage '
+      'Then fallbackLanguage is undetermined',
+      () {
+        // Arrange
+        final Map<ModelLanguage, String> translations = <ModelLanguage, String>{
+          ModelLanguage.spanishColombia: 'Hola',
+        };
+
+        // Act
+        final ModelLocalizedText model = ModelLocalizedText(
+          translations: translations,
+        );
+
+        // Assert
+        expect(
+          model.fallbackLanguage,
+          ModelLanguage.undetermined,
+        );
+      },
+    );
+
+    test(
+      'Given translations and fallbackLanguage '
+      'When model is created '
+      'Then values are preserved',
+      () {
+        // Arrange
+        final Map<ModelLanguage, String> translations = <ModelLanguage, String>{
+          ModelLanguage.spanishColombia: 'Hola',
+          ModelLanguage.englishUnitedStates: 'Hello',
+        };
+
+        // Act
+        final ModelLocalizedText model = ModelLocalizedText(
+          translations: translations,
+          fallbackLanguage: ModelLanguage.spanishColombia,
+        );
+
+        // Assert
+        expect(
+          model.translations,
+          <ModelLanguage, String>{
+            ModelLanguage.spanishColombia: 'Hola',
+            ModelLanguage.englishUnitedStates: 'Hello',
+          },
+        );
+        expect(
+          model.fallbackLanguage,
+          ModelLanguage.spanishColombia,
+        );
+      },
+    );
+
+    test(
+      'Given mutable translations '
+      'When model is created and input map changes '
+      'Then model translations remain unchanged',
+      () {
+        // Arrange
+        final Map<ModelLanguage, String> translations = <ModelLanguage, String>{
+          ModelLanguage.spanishColombia: 'Hola',
+        };
+
+        final ModelLocalizedText model = ModelLocalizedText(
+          translations: translations,
+        );
+
+        // Act
+        translations[ModelLanguage.spanishColombia] = 'Modificado';
+        translations[ModelLanguage.englishUnitedStates] = 'Hello';
+
+        // Assert
+        expect(
+          model.translations,
+          <ModelLanguage, String>{
+            ModelLanguage.spanishColombia: 'Hola',
+          },
+        );
+      },
+    );
+
+    test(
+      'Given a created model '
+      'When translations map is mutated '
+      'Then mutation throws UnsupportedError',
+      () {
+        // Arrange
+        final ModelLocalizedText model = ModelLocalizedText(
+          translations: <ModelLanguage, String>{
+            ModelLanguage.spanishColombia: 'Hola',
+          },
+        );
+
+        // Act
+        void mutateTranslations() {
+          model.translations[ModelLanguage.englishUnitedStates] = 'Hello';
+        }
+
+        // Assert
+        expect(
+          mutateTranslations,
+          throwsUnsupportedError,
+        );
+      },
+    );
+
+    test(
+      'Given empty translations '
+      'When model is created '
+      'Then empty map is preserved',
+      () {
+        // Act
+        final ModelLocalizedText model = ModelLocalizedText(
+          translations: const <ModelLanguage, String>{},
+        );
+
+        // Assert
+        expect(model.translations, isEmpty);
+        expect(
+          model.fallbackLanguage,
+          ModelLanguage.undetermined,
+        );
+      },
+    );
+  });
+
+  group('equality', () {
+    test(
+      'Given the same instance '
+      'When equality is evaluated '
+      'Then it is equal to itself',
+      () {
+        // Arrange
+        final ModelLocalizedText model = ModelLocalizedText(
+          translations: <ModelLanguage, String>{
+            ModelLanguage.spanishColombia: 'Hola',
+          },
+        );
+
+        // Act
+        final bool result = model == model;
+
+        // Assert
+        expect(result, isTrue);
+      },
+    );
+
+    test(
+      'Given different instances with same values '
+      'When equality is evaluated '
+      'Then they are equal',
+      () {
+        // Arrange
+        final ModelLocalizedText first = ModelLocalizedText(
+          translations: <ModelLanguage, String>{
+            ModelLanguage.spanishColombia: 'Hola',
+            ModelLanguage.englishUnitedStates: 'Hello',
+          },
+          fallbackLanguage: ModelLanguage.spanishColombia,
+        );
+
+        final ModelLocalizedText second = ModelLocalizedText(
+          translations: <ModelLanguage, String>{
+            ModelLanguage.spanishColombia: 'Hola',
+            ModelLanguage.englishUnitedStates: 'Hello',
+          },
+          fallbackLanguage: ModelLanguage.spanishColombia,
+        );
+
+        // Act & Assert
+        expect(first, equals(second));
+      },
+    );
+
+    test(
+      'Given translations inserted in different order '
+      'When equality is evaluated '
+      'Then models are equal',
+      () {
+        // Arrange
+        final ModelLocalizedText first = ModelLocalizedText(
+          translations: <ModelLanguage, String>{
+            ModelLanguage.spanishColombia: 'Hola',
+            ModelLanguage.englishUnitedStates: 'Hello',
+          },
+        );
+
+        final ModelLocalizedText second = ModelLocalizedText(
+          translations: <ModelLanguage, String>{
+            ModelLanguage.englishUnitedStates: 'Hello',
+            ModelLanguage.spanishColombia: 'Hola',
+          },
+        );
+
+        // Act & Assert
+        expect(first, equals(second));
+      },
+    );
+
+    test(
+      'Given different fallback languages '
+      'When equality is evaluated '
+      'Then models are not equal',
+      () {
+        // Arrange
+        final ModelLocalizedText first = ModelLocalizedText(
+          translations: <ModelLanguage, String>{
+            ModelLanguage.spanishColombia: 'Hola',
+          },
+          fallbackLanguage: ModelLanguage.spanishColombia,
+        );
+
+        final ModelLocalizedText second = ModelLocalizedText(
+          translations: <ModelLanguage, String>{
+            ModelLanguage.spanishColombia: 'Hola',
+          },
+          fallbackLanguage: ModelLanguage.englishUnitedStates,
+        );
+
+        // Act & Assert
+        expect(first, isNot(equals(second)));
+      },
+    );
+
+    test(
+      'Given different translation map lengths '
+      'When equality is evaluated '
+      'Then models are not equal',
+      () {
+        // Arrange
+        final ModelLocalizedText first = ModelLocalizedText(
+          translations: <ModelLanguage, String>{
+            ModelLanguage.spanishColombia: 'Hola',
+          },
+        );
+
+        final ModelLocalizedText second = ModelLocalizedText(
+          translations: <ModelLanguage, String>{
+            ModelLanguage.spanishColombia: 'Hola',
+            ModelLanguage.englishUnitedStates: 'Hello',
+          },
+        );
+
+        // Act & Assert
+        expect(first, isNot(equals(second)));
+      },
+    );
+
+    test(
+      'Given same translation count but different languages '
+      'When equality is evaluated '
+      'Then models are not equal',
+      () {
+        // Arrange
+        final ModelLocalizedText first = ModelLocalizedText(
+          translations: <ModelLanguage, String>{
+            ModelLanguage.spanishColombia: 'Hola',
+          },
+        );
+
+        final ModelLocalizedText second = ModelLocalizedText(
+          translations: <ModelLanguage, String>{
+            ModelLanguage.spanishMexico: 'Hola',
+          },
+        );
+
+        // Act & Assert
+        expect(first, isNot(equals(second)));
+      },
+    );
+
+    test(
+      'Given same languages but different text '
+      'When equality is evaluated '
+      'Then models are not equal',
+      () {
+        // Arrange
+        final ModelLocalizedText first = ModelLocalizedText(
+          translations: <ModelLanguage, String>{
+            ModelLanguage.spanishColombia: 'Hola',
+          },
+        );
+
+        final ModelLocalizedText second = ModelLocalizedText(
+          translations: <ModelLanguage, String>{
+            ModelLanguage.spanishColombia: 'Buenos días',
+          },
+        );
+
+        // Act & Assert
+        expect(first, isNot(equals(second)));
+      },
+    );
+
+    test(
+      'Given equal models '
+      'When hashCode is evaluated '
+      'Then hashCodes are equal',
+      () {
+        // Arrange
+        final ModelLocalizedText first = ModelLocalizedText(
+          translations: <ModelLanguage, String>{
+            ModelLanguage.spanishColombia: 'Hola',
+            ModelLanguage.englishUnitedStates: 'Hello',
+          },
+          fallbackLanguage: ModelLanguage.spanishColombia,
+        );
+
+        final ModelLocalizedText second = ModelLocalizedText(
+          translations: <ModelLanguage, String>{
+            ModelLanguage.spanishColombia: 'Hola',
+            ModelLanguage.englishUnitedStates: 'Hello',
+          },
+          fallbackLanguage: ModelLanguage.spanishColombia,
+        );
+
+        // Act & Assert
+        expect(first.hashCode, second.hashCode);
+      },
+    );
+
+    test(
+      'Given equal translations inserted in different order '
+      'When hashCode is evaluated '
+      'Then hashCodes are equal',
+      () {
+        // Arrange
+        final ModelLocalizedText first = ModelLocalizedText(
+          translations: <ModelLanguage, String>{
+            ModelLanguage.spanishColombia: 'Hola',
+            ModelLanguage.englishUnitedStates: 'Hello',
+          },
+        );
+
+        final ModelLocalizedText second = ModelLocalizedText(
+          translations: <ModelLanguage, String>{
+            ModelLanguage.englishUnitedStates: 'Hello',
+            ModelLanguage.spanishColombia: 'Hola',
+          },
+        );
+
+        // Act & Assert
+        expect(first.hashCode, second.hashCode);
+      },
+    );
+  });
+
+  group('fromJson', () {
+    test(
+      'Given valid JSON '
+      'When model is deserialized '
+      'Then translations and fallback are created',
+      () {
+        // Arrange
+        final Map<String, dynamic> json = <String, dynamic>{
+          ModelLocalizedText.translationsKey: <Map<String, dynamic>>[
+            <String, dynamic>{
+              ModelLocalizedText.languageKey: <String, dynamic>{
+                ModelLanguage.languageCodeKey: 'es',
+                ModelLanguage.scriptCodeKey: '',
+                ModelLanguage.regionCodeKey: 'CO',
+              },
+              ModelLocalizedText.textKey: 'Hola',
+            },
+            <String, dynamic>{
+              ModelLocalizedText.languageKey: <String, dynamic>{
+                ModelLanguage.languageCodeKey: 'en',
+                ModelLanguage.scriptCodeKey: '',
+                ModelLanguage.regionCodeKey: 'US',
+              },
+              ModelLocalizedText.textKey: 'Hello',
+            },
+          ],
+          ModelLocalizedText.fallbackLanguageKey: <String, dynamic>{
+            ModelLanguage.languageCodeKey: 'es',
+            ModelLanguage.scriptCodeKey: '',
+            ModelLanguage.regionCodeKey: 'CO',
+          },
+        };
+
+        // Act
+        final ModelLocalizedText model = ModelLocalizedText.fromJson(json);
+
+        // Assert
+        expect(
+          model.translations,
+          <ModelLanguage, String>{
+            ModelLanguage.spanishColombia: 'Hola',
+            ModelLanguage.englishUnitedStates: 'Hello',
+          },
+        );
+        expect(
+          model.fallbackLanguage,
+          ModelLanguage.spanishColombia,
+        );
+      },
+    );
+
+    test(
+      'Given language values with inconsistent casing and whitespace '
+      'When model is deserialized '
+      'Then languages are normalized by ModelLanguage',
+      () {
+        // Arrange
+        final Map<String, dynamic> json = <String, dynamic>{
+          ModelLocalizedText.translationsKey: <Map<String, dynamic>>[
+            <String, dynamic>{
+              ModelLocalizedText.languageKey: <String, dynamic>{
+                ModelLanguage.languageCodeKey: ' ES ',
+                ModelLanguage.scriptCodeKey: ' ',
+                ModelLanguage.regionCodeKey: ' co ',
+              },
+              ModelLocalizedText.textKey: 'Hola',
+            },
+          ],
+          ModelLocalizedText.fallbackLanguageKey: <String, dynamic>{
+            ModelLanguage.languageCodeKey: ' EN ',
+            ModelLanguage.scriptCodeKey: '',
+            ModelLanguage.regionCodeKey: ' us ',
+          },
+        };
+
+        // Act
+        final ModelLocalizedText model = ModelLocalizedText.fromJson(json);
+
+        // Assert
+        expect(
+          model.translations,
+          <ModelLanguage, String>{
+            ModelLanguage.spanishColombia: 'Hola',
+          },
+        );
+        expect(
+          model.fallbackLanguage,
+          ModelLanguage.englishUnitedStates,
+        );
+      },
+    );
+
+    test(
+      'Given script language values '
+      'When model is deserialized '
+      'Then script normalization is delegated to ModelLanguage',
+      () {
+        // Arrange
+        final Map<String, dynamic> json = <String, dynamic>{
+          ModelLocalizedText.translationsKey: <Map<String, dynamic>>[
+            <String, dynamic>{
+              ModelLocalizedText.languageKey: <String, dynamic>{
+                ModelLanguage.languageCodeKey: 'ZH',
+                ModelLanguage.scriptCodeKey: 'hANT',
+                ModelLanguage.regionCodeKey: 'tw',
+              },
+              ModelLocalizedText.textKey: '你好',
+            },
+          ],
+        };
+
+        // Act
+        final ModelLocalizedText model = ModelLocalizedText.fromJson(json);
+
+        // Assert
+        expect(
+          model.translations,
+          <ModelLanguage, String>{
+            ModelLanguage.chineseTaiwan: '你好',
+          },
+        );
+      },
+    );
+
+    test(
+      'Given missing translations '
+      'When model is deserialized '
+      'Then translations are empty',
+      () {
+        // Act
+        final ModelLocalizedText model = ModelLocalizedText.fromJson(
+          const <String, dynamic>{},
+        );
+
+        // Assert
+        expect(model.translations, isEmpty);
+      },
+    );
+
+    test(
+      'Given null translations '
+      'When model is deserialized '
+      'Then translations are empty',
+      () {
+        // Act
+        final ModelLocalizedText model = ModelLocalizedText.fromJson(
+          const <String, dynamic>{
+            ModelLocalizedText.translationsKey: null,
+          },
+        );
+
+        // Assert
+        expect(model.translations, isEmpty);
+      },
+    );
+
+    test(
+      'Given invalid non-list translations '
+      'When model is deserialized '
+      'Then translations are empty',
+      () {
+        // Act
+        final ModelLocalizedText model = ModelLocalizedText.fromJson(
+          const <String, dynamic>{
+            ModelLocalizedText.translationsKey: 'invalid',
+          },
+        );
+
+        // Assert
+        expect(model.translations, isEmpty);
+      },
+    );
+
+    test(
+      'Given non-map entries inside translations '
+      'When model is deserialized '
+      'Then invalid entries are ignored',
+      () {
+        // Arrange
+        final Map<String, dynamic> json = <String, dynamic>{
+          ModelLocalizedText.translationsKey: <dynamic>[
+            'invalid',
+            null,
+            42,
+            <String, dynamic>{
+              ModelLocalizedText.languageKey: <String, dynamic>{
+                ModelLanguage.languageCodeKey: 'es',
+                ModelLanguage.regionCodeKey: 'CO',
+              },
+              ModelLocalizedText.textKey: 'Hola',
+            },
+          ],
+        };
+
+        // Act
+        final ModelLocalizedText model = ModelLocalizedText.fromJson(json);
+
+        // Assert
+        expect(
+          model.translations,
+          <ModelLanguage, String>{
+            ModelLanguage.spanishColombia: 'Hola',
+          },
+        );
+      },
+    );
+
+    test(
+      'Given translation with missing language '
+      'When model is deserialized '
+      'Then language becomes undetermined',
+      () {
+        // Arrange
+        final Map<String, dynamic> json = <String, dynamic>{
+          ModelLocalizedText.translationsKey: <Map<String, dynamic>>[
+            <String, dynamic>{
+              ModelLocalizedText.textKey: 'Unknown text',
+            },
+          ],
+        };
+
+        // Act
+        final ModelLocalizedText model = ModelLocalizedText.fromJson(json);
+
+        // Assert
+        expect(
+          model.translations,
+          <ModelLanguage, String>{
+            ModelLanguage.undetermined: 'Unknown text',
+          },
+        );
+      },
+    );
+
+    test(
+      'Given translation with null language '
+      'When model is deserialized '
+      'Then language becomes undetermined',
+      () {
+        // Arrange
+        final Map<String, dynamic> json = <String, dynamic>{
+          ModelLocalizedText.translationsKey: <Map<String, dynamic>>[
+            <String, dynamic>{
+              ModelLocalizedText.languageKey: null,
+              ModelLocalizedText.textKey: 'Unknown text',
+            },
+          ],
+        };
+
+        // Act
+        final ModelLocalizedText model = ModelLocalizedText.fromJson(json);
+
+        // Assert
+        expect(
+          model.translations,
+          <ModelLanguage, String>{
+            ModelLanguage.undetermined: 'Unknown text',
+          },
+        );
+      },
+    );
+
+    test(
+      'Given translation with empty language code '
+      'When model is deserialized '
+      'Then language becomes undetermined',
+      () {
+        // Arrange
+        final Map<String, dynamic> json = <String, dynamic>{
+          ModelLocalizedText.translationsKey: <Map<String, dynamic>>[
+            <String, dynamic>{
+              ModelLocalizedText.languageKey: <String, dynamic>{
+                ModelLanguage.languageCodeKey: '',
+              },
+              ModelLocalizedText.textKey: 'Unknown text',
+            },
+          ],
+        };
+
+        // Act
+        final ModelLocalizedText model = ModelLocalizedText.fromJson(json);
+
+        // Assert
+        expect(
+          model.translations,
+          <ModelLanguage, String>{
+            ModelLanguage.undetermined: 'Unknown text',
+          },
+        );
+      },
+    );
+
+    test(
+      'Given translation with whitespace language code '
+      'When model is deserialized '
+      'Then language becomes undetermined',
+      () {
+        // Arrange
+        final Map<String, dynamic> json = <String, dynamic>{
+          ModelLocalizedText.translationsKey: <Map<String, dynamic>>[
+            <String, dynamic>{
+              ModelLocalizedText.languageKey: <String, dynamic>{
+                ModelLanguage.languageCodeKey: '   ',
+              },
+              ModelLocalizedText.textKey: 'Unknown text',
+            },
+          ],
+        };
+
+        // Act
+        final ModelLocalizedText model = ModelLocalizedText.fromJson(json);
+
+        // Assert
+        expect(
+          model.translations,
+          <ModelLanguage, String>{
+            ModelLanguage.undetermined: 'Unknown text',
+          },
+        );
+      },
+    );
+
+    test(
+      'Given missing translation text '
+      'When model is deserialized '
+      'Then text becomes empty string',
+      () {
+        // Arrange
+        final Map<String, dynamic> json = <String, dynamic>{
+          ModelLocalizedText.translationsKey: <Map<String, dynamic>>[
+            <String, dynamic>{
+              ModelLocalizedText.languageKey: <String, dynamic>{
+                ModelLanguage.languageCodeKey: 'es',
+                ModelLanguage.regionCodeKey: 'CO',
+              },
+            },
+          ],
+        };
+
+        // Act
+        final ModelLocalizedText model = ModelLocalizedText.fromJson(json);
+
+        // Assert
+        expect(
+          model.translations[ModelLanguage.spanishColombia],
+          '',
+        );
+      },
+    );
+
+    test(
+      'Given null translation text '
+      'When model is deserialized '
+      'Then text becomes empty string',
+      () {
+        // Arrange
+        final Map<String, dynamic> json = <String, dynamic>{
+          ModelLocalizedText.translationsKey: <Map<String, dynamic>>[
+            <String, dynamic>{
+              ModelLocalizedText.languageKey: <String, dynamic>{
+                ModelLanguage.languageCodeKey: 'es',
+                ModelLanguage.regionCodeKey: 'CO',
+              },
+              ModelLocalizedText.textKey: null,
+            },
+          ],
+        };
+
+        // Act
+        final ModelLocalizedText model = ModelLocalizedText.fromJson(json);
+
+        // Assert
+        expect(
+          model.translations[ModelLanguage.spanishColombia],
+          '',
+        );
+      },
+    );
+
+    test(
+      'Given non-string translation text '
+      'When model is deserialized '
+      'Then text is converted to String',
+      () {
+        // Arrange
+        final Map<String, dynamic> json = <String, dynamic>{
+          ModelLocalizedText.translationsKey: <Map<String, dynamic>>[
+            <String, dynamic>{
+              ModelLocalizedText.languageKey: <String, dynamic>{
+                ModelLanguage.languageCodeKey: 'es',
+                ModelLanguage.regionCodeKey: 'CO',
+              },
+              ModelLocalizedText.textKey: 42,
+            },
+          ],
+        };
+
+        // Act
+        final ModelLocalizedText model = ModelLocalizedText.fromJson(json);
+
+        // Assert
+        expect(
+          model.translations[ModelLanguage.spanishColombia],
+          '42',
+        );
+      },
+    );
+
+    test(
+      'Given missing fallbackLanguage '
+      'When model is deserialized '
+      'Then fallbackLanguage becomes undetermined',
+      () {
+        // Act
+        final ModelLocalizedText model = ModelLocalizedText.fromJson(
+          const <String, dynamic>{},
+        );
+
+        // Assert
+        expect(
+          model.fallbackLanguage,
+          ModelLanguage.undetermined,
+        );
+      },
+    );
+
+    test(
+      'Given null fallbackLanguage '
+      'When model is deserialized '
+      'Then fallbackLanguage becomes undetermined',
+      () {
+        // Act
+        final ModelLocalizedText model = ModelLocalizedText.fromJson(
+          const <String, dynamic>{
+            ModelLocalizedText.fallbackLanguageKey: null,
+          },
+        );
+
+        // Assert
+        expect(
+          model.fallbackLanguage,
+          ModelLanguage.undetermined,
+        );
+      },
+    );
+
+    test(
+      'Given invalid fallbackLanguage '
+      'When model is deserialized '
+      'Then fallbackLanguage becomes undetermined',
+      () {
+        // Act
+        final ModelLocalizedText model = ModelLocalizedText.fromJson(
+          const <String, dynamic>{
+            ModelLocalizedText.fallbackLanguageKey: 'invalid',
+          },
+        );
+
+        // Assert
+        expect(
+          model.fallbackLanguage,
+          ModelLanguage.undetermined,
+        );
+      },
+    );
+
+    test(
+      'Given duplicate translations resolving to same language '
+      'When model is deserialized '
+      'Then last translation wins',
+      () {
+        // Arrange
+        final Map<String, dynamic> json = <String, dynamic>{
+          ModelLocalizedText.translationsKey: <Map<String, dynamic>>[
+            <String, dynamic>{
+              ModelLocalizedText.languageKey: <String, dynamic>{
+                ModelLanguage.languageCodeKey: 'ES',
+                ModelLanguage.regionCodeKey: 'co',
+              },
+              ModelLocalizedText.textKey: 'Primero',
+            },
+            <String, dynamic>{
+              ModelLocalizedText.languageKey: <String, dynamic>{
+                ModelLanguage.languageCodeKey: 'es',
+                ModelLanguage.regionCodeKey: 'CO',
+              },
+              ModelLocalizedText.textKey: 'Último',
+            },
+          ],
+        };
+
+        // Act
+        final ModelLocalizedText model = ModelLocalizedText.fromJson(json);
+
+        // Assert
+        expect(model.translations.length, 1);
+        expect(
+          model.translations[ModelLanguage.spanishColombia],
+          'Último',
+        );
+      },
+    );
+
+    test(
+      'Given multiple entries resolving to undetermined '
+      'When model is deserialized '
+      'Then last undetermined translation wins',
+      () {
+        // Arrange
+        final Map<String, dynamic> json = <String, dynamic>{
+          ModelLocalizedText.translationsKey: <Map<String, dynamic>>[
+            <String, dynamic>{
+              ModelLocalizedText.textKey: 'Primero',
+            },
+            <String, dynamic>{
+              ModelLocalizedText.languageKey: <String, dynamic>{
+                ModelLanguage.languageCodeKey: '   ',
+              },
+              ModelLocalizedText.textKey: 'Último',
+            },
+          ],
+        };
+
+        // Act
+        final ModelLocalizedText model = ModelLocalizedText.fromJson(json);
+
+        // Assert
+        expect(model.translations.length, 1);
+        expect(
+          model.translations[ModelLanguage.undetermined],
+          'Último',
+        );
+      },
+    );
+
+    test(
+      'Given source JSON '
+      'When model is deserialized '
+      'Then input map remains untouched',
+      () {
+        // Arrange
+        final Map<String, dynamic> language = <String, dynamic>{
+          ModelLanguage.languageCodeKey: 'ES',
+          ModelLanguage.scriptCodeKey: '',
+          ModelLanguage.regionCodeKey: 'co',
+        };
+
+        final Map<String, dynamic> translation = <String, dynamic>{
+          ModelLocalizedText.languageKey: language,
+          ModelLocalizedText.textKey: 'Hola',
+        };
+
+        final List<Map<String, dynamic>> translations = <Map<String, dynamic>>[
+          translation,
+        ];
+
+        final Map<String, dynamic> json = <String, dynamic>{
+          ModelLocalizedText.translationsKey: translations,
+          ModelLocalizedText.fallbackLanguageKey: language,
+        };
+
+        // Act
+        ModelLocalizedText.fromJson(json);
+
+        // Assert
+        expect(
+          language,
+          <String, dynamic>{
+            ModelLanguage.languageCodeKey: 'ES',
+            ModelLanguage.scriptCodeKey: '',
+            ModelLanguage.regionCodeKey: 'co',
+          },
+        );
+
+        expect(
+          translation,
+          <String, dynamic>{
+            ModelLocalizedText.languageKey: language,
+            ModelLocalizedText.textKey: 'Hola',
+          },
+        );
+
+        expect(
+          translations,
+          <Map<String, dynamic>>[
+            translation,
+          ],
+        );
+      },
+    );
+  });
+
+  group('JSON keys', () {
+    test(
+      'Given ModelLocalizedText serialization contract '
+      'When static keys are read '
+      'Then keys remain deterministic',
+      () {
+        expect(
+          ModelLocalizedText.translationsKey,
+          'translations',
+        );
+        expect(
+          ModelLocalizedText.fallbackLanguageKey,
+          'fallbackLanguage',
+        );
+        expect(
+          ModelLocalizedText.languageKey,
+          'language',
+        );
+        expect(
+          ModelLocalizedText.textKey,
+          'text',
+        );
+      },
+    );
+  });
+
+  group('toJson', () {
+    test('supports JSON round trip', () {
+      final ModelLocalizedText original = ModelLocalizedText(
+        translations: <ModelLanguage, String>{
+          ModelLanguage.spanishColombia: 'Hola',
+          ModelLanguage.englishUnitedStates: 'Hello',
+          ModelLanguage.portugueseBrazil: 'Olá',
+        },
+        fallbackLanguage: ModelLanguage.spanishColombia,
+      );
+
+      final Map<String, dynamic> json = original.toJson();
+
+      final ModelLocalizedText restored = ModelLocalizedText.fromJson(json);
+
+      expect(restored, original);
+      expect(restored.hashCode, original.hashCode);
+    });
+    test('serializes translations in deterministic canonical order', () {
+      final ModelLocalizedText model = ModelLocalizedText(
+        translations: <ModelLanguage, String>{
+          ModelLanguage.spanishColombia: 'Hola',
+          ModelLanguage.portugueseBrazil: 'Olá',
+          ModelLanguage.englishUnitedStates: 'Hello',
+        },
+      );
+
+      final Map<String, dynamic> json = model.toJson();
+
+      final List<Map<String, dynamic>> translations = Utils.listFromDynamic(
+        json[ModelLocalizedText.translationsKey],
+      );
+
+      expect(
+        translations
+            .map(
+              (Map<String, dynamic> entry) => ModelLanguage.fromJson(
+                Utils.mapFromDynamic(
+                  entry[ModelLocalizedText.languageKey],
+                ),
+              ).canonicalTag,
+            )
+            .toList(),
+        <String>[
+          'en-US',
+          'es-CO',
+          'pt-BR',
+        ],
+      );
+    });
+    test(
+        'equal models serialize to equivalent JSON regardless of insertion order',
+        () {
+      final ModelLocalizedText first = ModelLocalizedText(
+        translations: <ModelLanguage, String>{
+          ModelLanguage.spanishColombia: 'Hola',
+          ModelLanguage.englishUnitedStates: 'Hello',
+        },
+      );
+
+      final ModelLocalizedText second = ModelLocalizedText(
+        translations: <ModelLanguage, String>{
+          ModelLanguage.englishUnitedStates: 'Hello',
+          ModelLanguage.spanishColombia: 'Hola',
+        },
+      );
+
+      expect(first, second);
+      expect(
+        Utils.deepEqualsMap(
+          first.toJson(),
+          second.toJson(),
+        ),
+        isTrue,
+      );
+    });
+  });
+}


### PR DESCRIPTION
# feat: add internationalization domain primitives

## Summary

Adds the first domain primitives required to support deterministic internationalization across Jocaagura consumers while keeping `jocaagura_domain` independent from Flutter localization APIs.

## Changes

* Adds `ModelLanguage` with:

  * Language, script, and region identifiers.
  * Built-in common language presets.
  * `und` fallback for undetermined languages.
  * Structural equality and deterministic `hashCode`.
  * Canonical language tag representation.
  * JSON serialization and normalized deserialization.
  * Lowercase language, title-case script, and uppercase region normalization.

* Adds `ModelLocalizedText` with:

  * Immutable `Map<ModelLanguage, String>` translations.
  * Defensive copying and unmodifiable storage.
  * Explicit fallback language.
  * Structural equality and deterministic `hashCode`.
  * Deterministic JSON serialization.
  * JSON deserialization using `ModelLanguage` normalization.
  * Stable translation ordering based on canonical language tags.
  * JSON round-trip support.

* Exports both models through the main `jocaagura_domain` library.

* Includes compatibility adjustments detected while validating the package against the current Flutter/Dart toolchain.

## Validation

* `dart format --set-exit-if-changed .`
* `flutter analyze`
* `flutter test`
* `ModelLanguage`: 100% line coverage.
* `ModelLocalizedText`: full behavioral coverage including immutability, equality, hashing, serialization, deserialization, normalization, deterministic ordering, and JSON round-trip.

## Compatibility

This change introduces new backward-compatible domain capabilities without modifying existing public contracts.

**SemVer:** `minor`
